### PR TITLE
fix: Updated version number

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 name: JM-Cosmos II
 desc: JM漫画下载插件 - 支持搜索、下载禁漫天堂的漫画本子，基于jmcomic库，支持加密PDF/ZIP打包
-version: v2.6.5
+version: v2.6.6
 author: GEMILUXVII
 repo: https://github.com/GEMILUXVII/astrbot_plugin_jm_cosmos


### PR DESCRIPTION
好像这忘记改了，不改的话要手动重装更新

## Summary by Sourcery

Bump the plugin metadata version from v2.6.5 to v2.6.6 to match the latest release and ensure automatic updates work correctly.