### PR TITLE
feat: 新增 SMTP 邮件投递功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .env
 *.pyc
 .pytest_cache/
+zhdocs/
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ JM-Cosmos II 是一个基于 AstrBot 开发的 JM 漫画下载插件，支持漫
 - **漫画搜索** - 通过关键词搜索 JM 漫画
 - **漫画详情** - 查看漫画信息、标签、作者等
 - **本子下载** - 下载完整本子（/jm）或单章节（/jmc）
+- **邮箱投递** - 支持通过 SMTP 将本子或章节作为加密附件发送到指定邮箱
 - **自动打包** - 下载完成后自动打包为 ZIP 或 PDF
 - **加密保护** - 支持为 ZIP/PDF 设置密码加密
 - **自动发送** - 打包后自动发送文件到聊天
@@ -109,6 +110,31 @@ pip install -r requirements.txt
 ```
 /jmc 123456 3   # 下载本子 123456 的第 3 章
 ```
+
+---
+
+#### `/jmemail <ID> <邮箱>`
+下载指定 ID 的完整本子，并通过 SMTP 发送到指定邮箱。
+
+```
+/jmemail 123456 user@example.com
+```
+
+- 保留原有 ZIP/PDF 打包与加密逻辑
+- 收件邮箱由命令参数指定
+- 当前要求 `pack_format` 为 `zip` 或 `pdf`
+
+---
+
+#### `/jmcemail <本子ID> <章节序号> <邮箱>`
+下载指定本子的指定章节，并通过 SMTP 发送到指定邮箱。
+
+```
+/jmcemail 123456 3 user@example.com
+```
+
+- 适合只投递单章内容
+- 同样复用现有打包、加密和文件命名机制
 
 ---
 
@@ -262,9 +288,50 @@ pip install -r requirements.txt
 | `admin_list`             | 管理员 ID 列表             | 空             | 逗号分隔，不受下载限制 |
 | `jm_username`            | JM账号用户名               | 空             | 面板配置可自动登录 |
 | `jm_password`            | JM账号密码                 | 空             | 命令登录重启后失效 |
+| `smtp_enabled`           | 启用SMTP邮箱发送           | `false`        | 开启后可使用 `/jmemail` 和 `/jmcemail` |
+| `smtp_host`              | SMTP服务器地址             | 空             | 例如 `smtp.qq.com` |
+| `smtp_port`              | SMTP端口                   | `465`          | SSL 常用 465，STARTTLS 常用 587 |
+| `smtp_use_ssl`           | SMTP使用SSL                | `true`         | 建议与 STARTTLS 二选一 |
+| `smtp_use_tls`           | SMTP使用STARTTLS           | `false`        | 建议与 SSL 二选一 |
+| `smtp_username`          | SMTP登录用户名             | 空             | 通常为发件邮箱 |
+| `smtp_password`          | SMTP密码/授权码            | 空             | 请勿直接写入普通邮箱登录密码 |
+| `smtp_from_email`        | 发件邮箱地址               | 空             | 邮件显示的发件地址 |
+| `smtp_from_name`         | 发件人名称                 | `JM-Cosmos II` | 邮件显示名称 |
+| `email_subject_template` | 邮件主题模板               | 内置默认值      | 支持 `{title}`、`{album_id}` 等变量 |
+| `email_body_template`    | 邮件正文模板               | 内置默认值      | 支持标题、作者、加密状态等变量 |
+| `email_max_attachment_mb`| 邮件附件大小限制           | `20`           | 超限将拒绝发送 |
+| `email_send_timeout`     | 邮件发送超时(秒)           | `60`           | SMTP 连接、登录与发送超时 |
 | `search_page_size`       | 搜索结果数量               | `5`            |  |
 | `daily_download_limit`   | 每日下载限制               | `0`            | 0=不限，管理员豁免 |
 | `debug_mode`             | 调试模式                   | `false`        |  |
+
+## 邮箱发送配置示例
+
+如果你希望使用 `/jmemail` 或 `/jmcemail`，请至少完成以下配置：
+
+| 配置项 | 示例值 |
+| ------ | ------ |
+| `smtp_enabled` | `true` |
+| `smtp_host` | `smtp.qq.com` |
+| `smtp_port` | `465` |
+| `smtp_use_ssl` | `true` |
+| `smtp_username` | `your_account@qq.com` |
+| `smtp_password` | `邮箱授权码` |
+| `smtp_from_email` | `your_account@qq.com` |
+
+> [!IMPORTANT]
+> 邮件功能使用的是 SMTP 授权码/应用专用密码，不建议直接使用邮箱网页登录密码。
+
+> [!NOTE]
+> `/jmemail` 与 `/jmcemail` 的收件人邮箱由命令参数传入，不会在插件中持久化保存。
+
+## 邮箱发送说明
+
+- 邮件命令会复用当前 `pack_format`、`pack_password` 和 `filename_show_password` 配置
+- 当 `pack_format = none` 时，邮件命令将拒绝执行，因为邮箱无法直接发送文件夹
+- 附件会在 SMTP 发送前按实际文件大小进行校验，超过 `email_max_attachment_mb` 时直接报错
+- 只有邮件发送成功后，`auto_delete_after_send` 才会清理本地文件
+- 如果发送失败，本地打包文件会保留，方便手动排查或二次发送
 
 ## 文件结构
 
@@ -280,6 +347,7 @@ astrbot_plugin_jm_cosmos/
 │   ├── browser.py       # 浏览查询器（搜索、排行、详情）
 │   ├── constants.py     # 常量定义
 │   ├── downloader.py    # 下载管理器
+│   ├── mailer.py        # SMTP 邮件发送模块
 │   ├── packer.py        # 打包模块 (ZIP/PDF)
 │   ├── quota.py         # 下载配额管理器
 │   └── base/            # 基础模块
@@ -318,6 +386,28 @@ proxy_url: http://127.0.0.1:7890
 ### Q: 如何只允许特定群使用？
 
 **A:** 在「启用的群列表」中填写群号（逗号分隔），如：`123456789,987654321`
+
+### Q: `/jmemail` 或 `/jmcemail` 提示 SMTP 配置不完整？
+
+**A:** 请检查至少以下配置项是否已填写：
+
+- `smtp_enabled = true`
+- `smtp_host`
+- `smtp_port`
+- `smtp_username`
+- `smtp_password`
+- `smtp_from_email`
+
+另外请确认 `smtp_use_ssl` 与 `smtp_use_tls` 不要同时开启。
+
+### Q: 邮件发送失败，提示附件过大？
+
+**A:** 这是 SMTP 常见限制，并不是插件 bug。可尝试：
+
+1. 改为发送单章：`/jmcemail`
+2. 降低图片体积或减少章节内容
+3. 提高 `email_max_attachment_mb`，但仍受邮箱服务商上限限制
+4. 改用原有 `/jm`、`/jmc` 平台内发送方式
 
 ### Q: Docker 部署时文件发送失败？
 

--- a/README.md
+++ b/README.md
@@ -122,12 +122,8 @@ pip install -r requirements.txt
 /jmemail 123456 a@example.com，b@example.com
 ```
 
-- 保留原有 ZIP/PDF 打包与加密逻辑
-- 收件邮箱由命令参数指定，支持英文逗号 `,` 或中文逗号 `，` 分隔多个邮箱
-- 空项会自动忽略，重复邮箱会自动去重
-- 为兼容不同聊天平台的参数解析，示例中建议不要在逗号两侧添加空格
-- 多个邮箱会作为同一封邮件的多个收件人写入 `To`
-- 当前要求 `pack_format` 为 `zip` 或 `pdf`
+- 邮件功能当前要求 `pack_format` 为 `zip` 或 `pdf`，不支持 `none`
+- 邮件收件人之间互相可见，请谨慎群发
 
 ---
 
@@ -138,11 +134,6 @@ pip install -r requirements.txt
 /jmcemail 123456 3 user@example.com
 /jmcemail 123456 3 a@example.com,b@example.com
 ```
-
-- 适合只投递单章内容
-- 同样复用现有打包、加密和文件命名机制
-- 若任一邮箱格式无效，会直接提示具体错误邮箱并终止发送
-- 多个邮箱会作为同一封邮件的多个收件人写入 `To`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -113,28 +113,36 @@ pip install -r requirements.txt
 
 ---
 
-#### `/jmemail <ID> <邮箱>`
-下载指定 ID 的完整本子，并通过 SMTP 发送到指定邮箱。
+#### `/jmemail <ID> <邮箱[,邮箱2,...]>`
+下载指定 ID 的完整本子，并通过 SMTP 发送到一个或多个指定邮箱。
 
 ```
 /jmemail 123456 user@example.com
+/jmemail 123456 a@example.com,b@example.com
+/jmemail 123456 a@example.com，b@example.com
 ```
 
 - 保留原有 ZIP/PDF 打包与加密逻辑
-- 收件邮箱由命令参数指定
+- 收件邮箱由命令参数指定，支持英文逗号 `,` 或中文逗号 `，` 分隔多个邮箱
+- 空项会自动忽略，重复邮箱会自动去重
+- 为兼容不同聊天平台的参数解析，示例中建议不要在逗号两侧添加空格
+- 多个邮箱会作为同一封邮件的多个收件人写入 `To`
 - 当前要求 `pack_format` 为 `zip` 或 `pdf`
 
 ---
 
-#### `/jmcemail <本子ID> <章节序号> <邮箱>`
-下载指定本子的指定章节，并通过 SMTP 发送到指定邮箱。
+#### `/jmcemail <本子ID> <章节序号> <邮箱[,邮箱2,...]>`
+下载指定本子的指定章节，并通过 SMTP 发送到一个或多个指定邮箱。
 
 ```
 /jmcemail 123456 3 user@example.com
+/jmcemail 123456 3 a@example.com,b@example.com
 ```
 
 - 适合只投递单章内容
 - 同样复用现有打包、加密和文件命名机制
+- 若任一邮箱格式无效，会直接提示具体错误邮箱并终止发送
+- 多个邮箱会作为同一封邮件的多个收件人写入 `To`
 
 ---
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -133,6 +133,84 @@
     "hint": "配合用户名使用，支持自动登录（可选）",
     "default": ""
   },
+  "smtp_enabled": {
+    "type": "bool",
+    "description": "启用SMTP邮箱发送",
+    "hint": "开启后可使用 /jmemail 和 /jmcemail 命令发送加密附件到邮箱",
+    "default": false
+  },
+  "smtp_host": {
+    "type": "string",
+    "description": "SMTP服务器地址",
+    "hint": "例如 smtp.qq.com、smtp.gmail.com",
+    "default": ""
+  },
+  "smtp_port": {
+    "type": "int",
+    "description": "SMTP端口",
+    "hint": "SSL 常用 465，STARTTLS 常用 587",
+    "default": 465
+  },
+  "smtp_use_ssl": {
+    "type": "bool",
+    "description": "SMTP使用SSL",
+    "hint": "通常与 465 端口配合使用，建议与 STARTTLS 二选一",
+    "default": true
+  },
+  "smtp_use_tls": {
+    "type": "bool",
+    "description": "SMTP使用STARTTLS",
+    "hint": "通常与 587 端口配合使用，建议与 SSL 二选一",
+    "default": false
+  },
+  "smtp_username": {
+    "type": "string",
+    "description": "SMTP登录用户名",
+    "hint": "通常为发件邮箱地址",
+    "default": ""
+  },
+  "smtp_password": {
+    "type": "string",
+    "description": "SMTP登录密码或授权码",
+    "hint": "请填写邮箱服务商提供的 SMTP 密码或授权码",
+    "default": ""
+  },
+  "smtp_from_email": {
+    "type": "string",
+    "description": "发件邮箱地址",
+    "hint": "邮件发件人地址",
+    "default": ""
+  },
+  "smtp_from_name": {
+    "type": "string",
+    "description": "发件人名称",
+    "hint": "邮件中显示的发件人名称",
+    "default": "JM-Cosmos II"
+  },
+  "email_subject_template": {
+    "type": "string",
+    "description": "邮件主题模板",
+    "hint": "支持 {album_id}、{title}、{recipient}、{pack_format} 等变量",
+    "default": "[JM-Cosmos II] {title} ({album_id})"
+  },
+  "email_body_template": {
+    "type": "text",
+    "description": "邮件正文模板",
+    "hint": "支持 {album_id}、{title}、{author}、{image_count}、{photo_count}、{pack_format}、{encrypted}、{recipient}",
+    "default": "下载任务已完成。\n\n标题: {title}\n本子ID: {album_id}\n作者: {author}\n章节数: {photo_count}\n图片数: {image_count}\n打包格式: {pack_format}\n已加密: {encrypted}\n收件人: {recipient}"
+  },
+  "email_max_attachment_mb": {
+    "type": "int",
+    "description": "邮箱附件大小限制(MB)",
+    "hint": "超过该大小将拒绝发送，以避免 SMTP 附件超限",
+    "default": 20
+  },
+  "email_send_timeout": {
+    "type": "int",
+    "description": "邮箱发送超时时间(秒)",
+    "hint": "SMTP 连接、登录与发送的超时时间",
+    "default": 60
+  },
   "search_page_size": {
     "type": "int",
     "description": "搜索结果每页数量",

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -10,6 +10,7 @@ from .auth import JMAuthManager
 from .base import JMClientMixin, JMConfigManager
 from .browser import JMBrowser
 from .downloader import DownloadResult, JMDownloadManager
+from .mailer import EmailSendResult, JMEmailSender
 from .packer import JMPacker
 from .quota import DownloadQuotaManager
 
@@ -25,5 +26,7 @@ __all__ = [
     "JMConfigManager",
     "JMDownloadManager",
     "DownloadResult",
+    "JMEmailSender",
+    "EmailSendResult",
     "JMPacker",
 ]

--- a/core/base/config.py
+++ b/core/base/config.py
@@ -141,6 +141,84 @@ class JMConfigManager:
         return self.plugin_config.get("jm_password", "")
 
     @property
+    def smtp_enabled(self) -> bool:
+        """是否启用 SMTP 邮件发送"""
+        return self.plugin_config.get("smtp_enabled", False)
+
+    @property
+    def smtp_host(self) -> str:
+        """SMTP 服务器地址"""
+        return self.plugin_config.get("smtp_host", "")
+
+    @property
+    def smtp_port(self) -> int:
+        """SMTP 端口"""
+        return self.plugin_config.get("smtp_port", 465)
+
+    @property
+    def smtp_use_ssl(self) -> bool:
+        """SMTP 是否使用 SSL"""
+        return self.plugin_config.get("smtp_use_ssl", True)
+
+    @property
+    def smtp_use_tls(self) -> bool:
+        """SMTP 是否使用 STARTTLS"""
+        return self.plugin_config.get("smtp_use_tls", False)
+
+    @property
+    def smtp_username(self) -> str:
+        """SMTP 用户名"""
+        return self.plugin_config.get("smtp_username", "")
+
+    @property
+    def smtp_password(self) -> str:
+        """SMTP 密码或授权码"""
+        return self.plugin_config.get("smtp_password", "")
+
+    @property
+    def smtp_from_email(self) -> str:
+        """SMTP 发件邮箱"""
+        return self.plugin_config.get("smtp_from_email", "")
+
+    @property
+    def smtp_from_name(self) -> str:
+        """SMTP 发件人名称"""
+        return self.plugin_config.get("smtp_from_name", "JM-Cosmos II")
+
+    @property
+    def email_subject_template(self) -> str:
+        """邮件主题模板"""
+        return self.plugin_config.get(
+            "email_subject_template", "[JM-Cosmos II] {title} ({album_id})"
+        )
+
+    @property
+    def email_body_template(self) -> str:
+        """邮件正文模板"""
+        return self.plugin_config.get(
+            "email_body_template",
+            "下载任务已完成。\n\n"
+            "标题: {title}\n"
+            "本子ID: {album_id}\n"
+            "作者: {author}\n"
+            "章节数: {photo_count}\n"
+            "图片数: {image_count}\n"
+            "打包格式: {pack_format}\n"
+            "已加密: {encrypted}\n"
+            "收件人: {recipient}",
+        )
+
+    @property
+    def email_max_attachment_mb(self) -> int:
+        """邮件附件大小限制（MB）"""
+        return self.plugin_config.get("email_max_attachment_mb", 20)
+
+    @property
+    def email_send_timeout(self) -> int:
+        """邮件发送超时时间（秒）"""
+        return self.plugin_config.get("email_send_timeout", 60)
+
+    @property
     def auto_recall_enabled(self) -> bool:
         """是否启用自动撤回"""
         return self.plugin_config.get("auto_recall_enabled", False)

--- a/core/mailer.py
+++ b/core/mailer.py
@@ -9,6 +9,7 @@ import smtplib
 import ssl
 from dataclasses import dataclass
 from email.message import EmailMessage
+from email.utils import make_msgid
 from pathlib import Path
 
 from astrbot.api import logger
@@ -120,6 +121,7 @@ class JMEmailSender(JMClientMixin):
                 else self.config.smtp_from_email
             )
             message["To"] = recipient
+            message["Message-ID"] = make_msgid()
             message.set_content(body)
 
             mime_type, _ = mimetypes.guess_type(file_path.name)
@@ -160,12 +162,22 @@ class JMEmailSender(JMClientMixin):
 
             if response:
                 return EmailSendResult(
-                    False, recipient, f"部分收件人发送失败: {response}"
+                    False,
+                    recipient,
+                    f"部分收件人发送失败: {response}",
+                    str(message["Message-ID"]),
                 )
 
             logger.info(f"邮件发送成功: {recipient} <- {file_path.name}")
-            return EmailSendResult(True, recipient)
+            return EmailSendResult(
+                True, recipient, message_id=str(message["Message-ID"])
+            )
 
         except Exception as e:
             logger.error(f"SMTP 发送失败 ({recipient}): {e}")
-            return EmailSendResult(False, recipient, str(e))
+            return EmailSendResult(
+                False,
+                recipient,
+                str(e),
+                str(message["Message-ID"]) if "message" in locals() else None,
+            )

--- a/core/mailer.py
+++ b/core/mailer.py
@@ -78,40 +78,44 @@ class JMEmailSender(JMClientMixin):
 
     async def send_file(
         self,
-        recipient: str,
+        recipients: list[str],
         file_path: Path,
         subject: str,
         body: str,
     ) -> EmailSendResult:
         """异步发送附件邮件"""
+        recipient_text = ", ".join(recipients)
+
         ok, message = self.validate_config()
         if not ok:
-            return EmailSendResult(False, recipient, message)
+            return EmailSendResult(False, recipient_text, message)
 
         ok, message = self.validate_attachment(file_path)
         if not ok:
-            return EmailSendResult(False, recipient, message)
+            return EmailSendResult(False, recipient_text, message)
 
         try:
             return await self._run_sync(
                 self._send_file_sync,
-                recipient,
+                recipients,
                 file_path,
                 subject,
                 body,
             )
         except Exception as e:
             logger.error(f"发送邮件失败: {e}")
-            return EmailSendResult(False, recipient, str(e))
+            return EmailSendResult(False, recipient_text, str(e))
 
     def _send_file_sync(
         self,
-        recipient: str,
+        recipients: list[str],
         file_path: Path,
         subject: str,
         body: str,
     ) -> EmailSendResult:
         """同步发送附件邮件"""
+        recipient_text = ", ".join(recipients)
+
         try:
             message = EmailMessage()
             message["Subject"] = subject
@@ -120,7 +124,7 @@ class JMEmailSender(JMClientMixin):
                 if self.config.smtp_from_name
                 else self.config.smtp_from_email
             )
-            message["To"] = recipient
+            message["To"] = recipient_text
             message["Message-ID"] = make_msgid()
             message.set_content(body)
 
@@ -163,21 +167,21 @@ class JMEmailSender(JMClientMixin):
             if response:
                 return EmailSendResult(
                     False,
-                    recipient,
+                    recipient_text,
                     f"部分收件人发送失败: {response}",
                     str(message["Message-ID"]),
                 )
 
-            logger.info(f"邮件发送成功: {recipient} <- {file_path.name}")
+            logger.info(f"邮件发送成功: {recipient_text} <- {file_path.name}")
             return EmailSendResult(
-                True, recipient, message_id=str(message["Message-ID"])
+                True, recipient_text, message_id=str(message["Message-ID"])
             )
 
         except Exception as e:
-            logger.error(f"SMTP 发送失败 ({recipient}): {e}")
+            logger.error(f"SMTP 发送失败 ({recipient_text}): {e}")
             return EmailSendResult(
                 False,
-                recipient,
+                recipient_text,
                 str(e),
                 str(message["Message-ID"]) if "message" in locals() else None,
             )

--- a/core/mailer.py
+++ b/core/mailer.py
@@ -1,0 +1,171 @@
+"""
+JMComic 邮件发送模块
+
+提供 SMTP 附件发送能力，用于将下载后的加密文件发送到邮箱。
+"""
+
+import mimetypes
+import smtplib
+import ssl
+from dataclasses import dataclass
+from email.message import EmailMessage
+from pathlib import Path
+
+from astrbot.api import logger
+
+from .base import JMClientMixin, JMConfigManager
+
+
+@dataclass
+class EmailSendResult:
+    """邮件发送结果"""
+
+    success: bool
+    recipient: str
+    error_message: str | None = None
+    message_id: str | None = None
+
+
+class JMEmailSender(JMClientMixin):
+    """SMTP 邮件发送器"""
+
+    def __init__(self, config_manager: JMConfigManager):
+        self.config = config_manager
+
+    def validate_config(self) -> tuple[bool, str]:
+        """检查 SMTP 配置是否完整可用"""
+        if not self.config.smtp_enabled:
+            return False, "未启用 SMTP 邮件发送，请先在插件配置中开启"
+
+        required_fields = {
+            "smtp_host": self.config.smtp_host,
+            "smtp_username": self.config.smtp_username,
+            "smtp_password": self.config.smtp_password,
+            "smtp_from_email": self.config.smtp_from_email,
+        }
+        missing_fields = [name for name, value in required_fields.items() if not value]
+        if missing_fields:
+            return False, f"SMTP 配置不完整，缺少: {', '.join(missing_fields)}"
+
+        if self.config.smtp_port <= 0:
+            return False, "SMTP 端口必须大于 0"
+
+        if self.config.smtp_use_ssl and self.config.smtp_use_tls:
+            return False, "SMTP SSL 与 STARTTLS 不能同时启用"
+
+        return True, ""
+
+    def validate_attachment(self, file_path: Path) -> tuple[bool, str]:
+        """检查附件是否可发送"""
+        if not file_path.exists() or not file_path.is_file():
+            return False, "附件文件不存在"
+
+        limit_mb = self.config.email_max_attachment_mb
+        if limit_mb <= 0:
+            return True, ""
+
+        file_size = file_path.stat().st_size
+        limit_bytes = limit_mb * 1024 * 1024
+        if file_size > limit_bytes:
+            current_mb = file_size / 1024 / 1024
+            return (
+                False,
+                f"附件过大 ({current_mb:.1f}MB)，超过邮箱限制 {limit_mb}MB",
+            )
+
+        return True, ""
+
+    async def send_file(
+        self,
+        recipient: str,
+        file_path: Path,
+        subject: str,
+        body: str,
+    ) -> EmailSendResult:
+        """异步发送附件邮件"""
+        ok, message = self.validate_config()
+        if not ok:
+            return EmailSendResult(False, recipient, message)
+
+        ok, message = self.validate_attachment(file_path)
+        if not ok:
+            return EmailSendResult(False, recipient, message)
+
+        try:
+            return await self._run_sync(
+                self._send_file_sync,
+                recipient,
+                file_path,
+                subject,
+                body,
+            )
+        except Exception as e:
+            logger.error(f"发送邮件失败: {e}")
+            return EmailSendResult(False, recipient, str(e))
+
+    def _send_file_sync(
+        self,
+        recipient: str,
+        file_path: Path,
+        subject: str,
+        body: str,
+    ) -> EmailSendResult:
+        """同步发送附件邮件"""
+        try:
+            message = EmailMessage()
+            message["Subject"] = subject
+            message["From"] = (
+                f"{self.config.smtp_from_name} <{self.config.smtp_from_email}>"
+                if self.config.smtp_from_name
+                else self.config.smtp_from_email
+            )
+            message["To"] = recipient
+            message.set_content(body)
+
+            mime_type, _ = mimetypes.guess_type(file_path.name)
+            if mime_type is None:
+                maintype, subtype = "application", "octet-stream"
+            else:
+                maintype, subtype = mime_type.split("/", 1)
+
+            with open(file_path, "rb") as f:
+                message.add_attachment(
+                    f.read(),
+                    maintype=maintype,
+                    subtype=subtype,
+                    filename=file_path.name,
+                )
+
+            timeout = self.config.email_send_timeout
+            if self.config.smtp_use_ssl:
+                context = ssl.create_default_context()
+                with smtplib.SMTP_SSL(
+                    self.config.smtp_host,
+                    self.config.smtp_port,
+                    timeout=timeout,
+                    context=context,
+                ) as server:
+                    server.login(self.config.smtp_username, self.config.smtp_password)
+                    response = server.send_message(message)
+            else:
+                with smtplib.SMTP(
+                    self.config.smtp_host,
+                    self.config.smtp_port,
+                    timeout=timeout,
+                ) as server:
+                    if self.config.smtp_use_tls:
+                        server.starttls(context=ssl.create_default_context())
+                    server.login(self.config.smtp_username, self.config.smtp_password)
+                    response = server.send_message(message)
+
+            if response:
+                return EmailSendResult(
+                    False, recipient, f"部分收件人发送失败: {response}"
+                )
+
+            logger.info(f"邮件发送成功: {recipient} <- {file_path.name}")
+            return EmailSendResult(True, recipient)
+
+        except Exception as e:
+            logger.error(f"SMTP 发送失败 ({recipient}): {e}")
+            return EmailSendResult(False, recipient, str(e))

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ JM-Cosmos II - AstrBot JM漫画下载插件
 支持搜索、下载禁漫天堂的漫画本子，基于jmcomic库
 """
 
+import re
 from pathlib import Path
 
 import astrbot.api.message_components as Comp
@@ -17,6 +18,7 @@ from .core import (
     JMBrowser,
     JMConfigManager,
     JMDownloadManager,
+    JMEmailSender,
     JMPacker,
 )
 from .utils import MessageFormatter, generate_album_filename, send_with_recall
@@ -63,6 +65,9 @@ class JMCosmosPlugin(Star):
         # 初始化认证管理器
         self.auth_manager = JMAuthManager(self.config_manager)
 
+        # 初始化邮件发送器
+        self.email_sender = JMEmailSender(self.config_manager)
+
         # 初始化下载配额管理器
         self.quota_manager = DownloadQuotaManager(self.data_dir / "quota.db")
 
@@ -92,6 +97,201 @@ class JMCosmosPlugin(Star):
             return False, MessageFormatter.format_error("group_disabled")
 
         return True, ""
+
+    @staticmethod
+    def _is_valid_email(email: str) -> bool:
+        """校验邮箱格式"""
+        return bool(re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email))
+
+    def _check_download_quota(self, user_id: str) -> tuple[bool, str, int]:
+        """检查下载配额"""
+        limit = self.config_manager.daily_download_limit
+        is_admin = str(user_id) in self.config_manager.admin_list
+        if limit > 0 and not is_admin:
+            can_download, used, total = self.quota_manager.check_quota(user_id, limit)
+            if not can_download:
+                return (
+                    False,
+                    f"❌ 今日下载次数已达上限 ({used}/{total})\n请明天再试",
+                    limit,
+                )
+
+        return True, "", limit
+
+    def _build_packer(self) -> JMPacker:
+        """创建打包器"""
+        return JMPacker(
+            pack_format=self.config_manager.pack_format,
+            password=self.config_manager.pack_password,
+        )
+
+    def _cleanup_download_files(self, result, pack_result) -> None:
+        """清理下载和打包产物"""
+        if self.config_manager.auto_delete_after_send:
+            JMPacker.cleanup(result.save_path)
+            if pack_result.output_path and pack_result.format != "none":
+                JMPacker.cleanup(pack_result.output_path)
+
+    def _build_email_context(
+        self, result, pack_result, recipient: str
+    ) -> dict[str, str]:
+        """构建邮件模板上下文"""
+        return {
+            "album_id": result.album_id,
+            "title": result.title or result.album_id,
+            "author": result.author or "未知",
+            "photo_count": str(result.photo_count),
+            "image_count": str(result.image_count),
+            "pack_format": pack_result.format,
+            "encrypted": "是" if pack_result.encrypted else "否",
+            "recipient": recipient,
+        }
+
+    async def _send_file_to_email(
+        self, result, pack_result, recipient: str
+    ) -> tuple[bool, str]:
+        """通过 SMTP 发送文件到邮箱"""
+        if self.config_manager.pack_format == "none":
+            return False, "当前打包格式为 none，邮件命令仅支持 zip 或 pdf"
+
+        if not pack_result.success or not pack_result.output_path:
+            return False, pack_result.error_message or "打包失败，无法发送邮件"
+
+        context = self._build_email_context(result, pack_result, recipient)
+
+        try:
+            subject = self.config_manager.email_subject_template.format(**context)
+            body = self.config_manager.email_body_template.format(**context)
+        except KeyError as e:
+            return False, f"邮件模板变量无效: {e}"
+
+        email_result = await self.email_sender.send_file(
+            recipient=recipient,
+            file_path=pack_result.output_path,
+            subject=subject,
+            body=body,
+        )
+
+        if not email_result.success:
+            return False, email_result.error_message or "邮件发送失败"
+
+        return True, MessageFormatter.format_email_send_result(
+            result,
+            pack_result,
+            recipient,
+        )
+
+    async def _send_file_to_platform(
+        self, event: AstrMessageEvent, result_msg: str, pack_result
+    ):
+        """发送文件到当前消息平台并返回结果对象"""
+        file_path_str = str(pack_result.output_path)
+        logger.info(f"准备发送文件: {file_path_str}")
+
+        from astrbot.api.event import MessageChain
+
+        file_chain = MessageChain(
+            [
+                Comp.Plain(result_msg),
+                Comp.File(
+                    name=pack_result.output_path.name,
+                    file=file_path_str,
+                ),
+            ]
+        )
+
+        if self.config_manager.auto_recall_enabled:
+            await send_with_recall(
+                event,
+                file_chain,
+                self.config_manager.auto_recall_delay,
+            )
+            return None
+        else:
+            return event.chain_result(file_chain.chain)
+
+    async def _prepare_album_download(self, album_id: str):
+        """下载并打包整本漫画"""
+        result = await self.download_manager.download_album(album_id)
+        if not result.success:
+            return result, None
+
+        output_name = generate_album_filename(
+            album_id=album_id,
+            password=self.config_manager.pack_password,
+            show_password=self.config_manager.filename_show_password,
+        )
+        pack_result = self._build_packer().pack(
+            source_dir=result.save_path,
+            output_name=output_name,
+        )
+        return result, pack_result
+
+    async def _prepare_photo_download(self, album_id: str, chapter_idx: int):
+        """下载并打包单章节漫画"""
+        chapter_info = await self.browser.get_photo_id_by_index(album_id, chapter_idx)
+        if chapter_info is None:
+            return None, None, None
+
+        photo_id, photo_title, total_chapters = chapter_info
+        result = await self.download_manager.download_photo(photo_id)
+        if not result.success:
+            return result, None, (photo_title, total_chapters)
+
+        output_name = generate_album_filename(
+            album_id=album_id,
+            password=self.config_manager.pack_password,
+            chapter_idx=chapter_idx,
+            show_password=self.config_manager.filename_show_password,
+        )
+        pack_result = self._build_packer().pack(
+            source_dir=result.save_path,
+            output_name=output_name,
+        )
+        return result, pack_result, (photo_title, total_chapters)
+
+    async def _send_cover_preview_if_needed(
+        self, event: AstrMessageEvent, album_id: str
+    ) -> None:
+        """按配置发送封面预览"""
+        if not self.config_manager.send_cover_preview:
+            return
+
+        detail = await self.browser.get_album_detail(album_id)
+        if not detail:
+            return
+
+        cover_dir = self.config_manager.download_dir / "covers"
+        cover_path = await self.browser.get_album_cover(album_id, cover_dir)
+
+        if cover_path and cover_path.exists():
+            from astrbot.api.event import MessageChain
+
+            cover_chain = MessageChain(
+                [
+                    Comp.Image(file=str(cover_path)),
+                    Comp.Plain(MessageFormatter.format_album_info(detail)),
+                ]
+            )
+
+            if self.config_manager.cover_recall_enabled:
+                await send_with_recall(
+                    event,
+                    cover_chain,
+                    self.config_manager.auto_recall_delay,
+                )
+            else:
+                yield_result = event.chain_result(cover_chain.chain)
+                if yield_result is not None:
+                    return yield_result
+        else:
+            plain_result = event.plain_result(
+                MessageFormatter.format_album_info(detail)
+            )
+            if plain_result is not None:
+                return plain_result
+
+        return None
 
     @filter.command("jmhelp")
     async def help_command(self, event: AstrMessageEvent):
@@ -127,57 +327,21 @@ class JMCosmosPlugin(Star):
             yield event.plain_result(MessageFormatter.format_error("invalid_id"))
             return
 
-        # 检查下载配额（管理员豁免）
         user_id = event.get_sender_id()
-        limit = self.config_manager.daily_download_limit
-        is_admin = str(user_id) in self.config_manager.admin_list
-        if limit > 0 and not is_admin:
-            can_download, used, total = self.quota_manager.check_quota(user_id, limit)
-            if not can_download:
-                yield event.plain_result(
-                    f"❌ 今日下载次数已达上限 ({used}/{total})\n请明天再试"
-                )
-                return
+        can_download, quota_msg, limit = self._check_download_quota(user_id)
+        if not can_download:
+            yield event.plain_result(quota_msg)
+            return
 
         try:
             # 发送开始下载提示
             yield event.plain_result(f"⏳ 开始下载本子 {album_id}，请稍候...")
 
-            # 如果配置了发送封面预览，获取详情和封面
-            if self.config_manager.send_cover_preview:
-                detail = await self.browser.get_album_detail(album_id)
-                if detail:
-                    # 获取封面图片
-                    cover_dir = self.config_manager.download_dir / "covers"
-                    cover_path = await self.browser.get_album_cover(album_id, cover_dir)
+            preview_result = await self._send_cover_preview_if_needed(event, album_id)
+            if preview_result is not None:
+                yield preview_result
 
-                    if cover_path and cover_path.exists():
-                        # 构建封面消息链
-                        from astrbot.api.event import MessageChain
-
-                        cover_chain = MessageChain(
-                            [
-                                Comp.Image(file=str(cover_path)),
-                                Comp.Plain(MessageFormatter.format_album_info(detail)),
-                            ]
-                        )
-
-                        # 根据配置决定是否对封面消息自动撤回
-                        if self.config_manager.cover_recall_enabled:
-                            await send_with_recall(
-                                event,
-                                cover_chain,
-                                self.config_manager.auto_recall_delay,
-                            )
-                        else:
-                            yield event.chain_result(cover_chain.chain)
-                    else:
-                        yield event.plain_result(
-                            MessageFormatter.format_album_info(detail)
-                        )
-
-            # 执行下载
-            result = await self.download_manager.download_album(album_id)
+            result, pack_result = await self._prepare_album_download(album_id)
 
             if not result.success:
                 yield event.plain_result(
@@ -187,26 +351,6 @@ class JMCosmosPlugin(Star):
                 )
                 return
 
-            # 生成文件名
-            output_name = generate_album_filename(
-                album_id=album_id,
-                password=self.config_manager.pack_password,
-                show_password=self.config_manager.filename_show_password,
-            )
-
-            # 打包文件
-            packer = JMPacker(
-                pack_format=self.config_manager.pack_format,
-                password=self.config_manager.pack_password,
-            )
-
-            pack_result = packer.pack(
-                source_dir=result.save_path,
-                output_name=output_name,
-            )
-
-            # 发送结果消息
-            # 下载成功，消耗配额
             if limit > 0:
                 self.quota_manager.consume_quota(user_id)
 
@@ -217,37 +361,15 @@ class JMCosmosPlugin(Star):
                 and pack_result.output_path
                 and pack_result.format != "none"
             ):
-                # 构建文件路径 - 调试输出
-                file_path_str = str(pack_result.output_path)
-                logger.info(f"准备发送文件: {file_path_str}")
-
-                # 构建消息链
-                from astrbot.api.event import MessageChain
-
-                file_chain = MessageChain(
-                    [
-                        Comp.Plain(result_msg),
-                        Comp.File(
-                            name=pack_result.output_path.name,
-                            file=file_path_str,
-                        ),
-                    ]
+                platform_result = await self._send_file_to_platform(
+                    event,
+                    result_msg,
+                    pack_result,
                 )
+                if platform_result is not None:
+                    yield platform_result
 
-                # 根据配置决定是否使用自动撤回
-                if self.config_manager.auto_recall_enabled:
-                    await send_with_recall(
-                        event,
-                        file_chain,
-                        self.config_manager.auto_recall_delay,
-                    )
-                else:
-                    yield event.chain_result(file_chain.chain)
-
-                # 自动清理
-                if self.config_manager.auto_delete_after_send:
-                    JMPacker.cleanup(result.save_path)
-                    JMPacker.cleanup(pack_result.output_path)
+                self._cleanup_download_files(result, pack_result)
             else:
                 yield event.plain_result(result_msg)
 
@@ -299,29 +421,23 @@ class JMCosmosPlugin(Star):
             yield event.plain_result("❌ 章节序号必须是数字")
             return
 
-        # 检查下载配额（管理员豁免）
         user_id = event.get_sender_id()
-        limit = self.config_manager.daily_download_limit
-        is_admin = str(user_id) in self.config_manager.admin_list
-        if limit > 0 and not is_admin:
-            can_download, used, total = self.quota_manager.check_quota(user_id, limit)
-            if not can_download:
-                yield event.plain_result(
-                    f"❌ 今日下载次数已达上限 ({used}/{total})\n请明天再试"
-                )
-                return
+        can_download, quota_msg, limit = self._check_download_quota(user_id)
+        if not can_download:
+            yield event.plain_result(quota_msg)
+            return
 
         try:
             yield event.plain_result(
                 f"⏳ 正在获取本子 {album_id} 的第 {chapter_idx} 章节信息..."
             )
 
-            # 获取章节的真正 photo_id
-            chapter_info = await self.browser.get_photo_id_by_index(
-                album_id, chapter_idx
+            result, pack_result, chapter_meta = await self._prepare_photo_download(
+                album_id,
+                chapter_idx,
             )
 
-            if chapter_info is None:
+            if result is None:
                 yield event.plain_result(
                     f"❌ 无法获取章节信息\n可能的原因:\n"
                     f"• 本子 {album_id} 不存在\n"
@@ -329,16 +445,13 @@ class JMCosmosPlugin(Star):
                 )
                 return
 
-            photo_id, photo_title, total_chapters = chapter_info
+            photo_title, total_chapters = chapter_meta
 
             yield event.plain_result(
                 f"📖 找到章节: {photo_title}\n"
                 f"📚 章节: {chapter_idx}/{total_chapters}\n"
                 f"⏳ 开始下载..."
             )
-
-            # 使用真正的 photo_id 下载
-            result = await self.download_manager.download_photo(photo_id)
 
             if not result.success:
                 yield event.plain_result(
@@ -348,26 +461,6 @@ class JMCosmosPlugin(Star):
                 )
                 return
 
-            # 生成文件名（带章节号）
-            output_name = generate_album_filename(
-                album_id=album_id,
-                password=self.config_manager.pack_password,
-                chapter_idx=chapter_idx,
-                show_password=self.config_manager.filename_show_password,
-            )
-
-            # 打包
-            packer = JMPacker(
-                pack_format=self.config_manager.pack_format,
-                password=self.config_manager.pack_password,
-            )
-
-            pack_result = packer.pack(
-                source_dir=result.save_path,
-                output_name=output_name,
-            )
-
-            # 下载成功，消耗配额
             if limit > 0:
                 self.quota_manager.consume_quota(user_id)
 
@@ -378,40 +471,202 @@ class JMCosmosPlugin(Star):
                 and pack_result.output_path
                 and pack_result.format != "none"
             ):
-                file_path_str = str(pack_result.output_path)
-                logger.info(f"准备发送章节文件: {file_path_str}")
-
-                # 构建消息链
-                from astrbot.api.event import MessageChain
-
-                file_chain = MessageChain(
-                    [
-                        Comp.Plain(result_msg),
-                        Comp.File(
-                            name=pack_result.output_path.name,
-                            file=file_path_str,
-                        ),
-                    ]
+                platform_result = await self._send_file_to_platform(
+                    event,
+                    result_msg,
+                    pack_result,
                 )
+                if platform_result is not None:
+                    yield platform_result
 
-                # 根据配置决定是否使用自动撤回
-                if self.config_manager.auto_recall_enabled:
-                    await send_with_recall(
-                        event,
-                        file_chain,
-                        self.config_manager.auto_recall_delay,
-                    )
-                else:
-                    yield event.chain_result(file_chain.chain)
-
-                if self.config_manager.auto_delete_after_send:
-                    JMPacker.cleanup(result.save_path)
-                    JMPacker.cleanup(pack_result.output_path)
+                self._cleanup_download_files(result, pack_result)
             else:
                 yield event.plain_result(result_msg)
 
         except Exception as e:
             logger.error(f"下载章节失败: {e}")
+            yield event.plain_result(
+                MessageFormatter.format_error("download_failed", str(e))
+            )
+
+    @filter.command("jmemail")
+    async def download_album_email_command(
+        self,
+        event: AstrMessageEvent,
+        album_id: str = None,
+        recipient_email: str = None,
+    ):
+        """
+        下载指定 ID 的漫画并发送到邮箱
+
+        用法: /jmemail <ID> <邮箱>
+        示例: /jmemail 123456 user@example.com
+        """
+        has_perm, error_msg = self._check_permission(event)
+        if not has_perm:
+            yield event.plain_result(error_msg)
+            return
+
+        if album_id is None or recipient_email is None:
+            yield event.plain_result(
+                "❌ 请提供本子ID和邮箱\n用法: /jmemail <ID> <邮箱>\n示例: /jmemail 123456 user@example.com"
+            )
+            return
+
+        album_id = str(album_id).strip()
+        recipient_email = str(recipient_email).strip()
+
+        if not album_id.isdigit():
+            yield event.plain_result(MessageFormatter.format_error("invalid_id"))
+            return
+
+        if not self._is_valid_email(recipient_email):
+            yield event.plain_result("❌ 邮箱格式无效，请输入正确的邮箱地址")
+            return
+
+        user_id = event.get_sender_id()
+        can_download, quota_msg, limit = self._check_download_quota(user_id)
+        if not can_download:
+            yield event.plain_result(quota_msg)
+            return
+
+        try:
+            yield event.plain_result(
+                f"📮 开始下载本子 {album_id} 并发送到邮箱 {recipient_email}，请稍候..."
+            )
+
+            result, pack_result = await self._prepare_album_download(album_id)
+            if not result.success:
+                yield event.plain_result(
+                    MessageFormatter.format_error(
+                        "download_failed", result.error_message
+                    )
+                )
+                return
+
+            if limit > 0:
+                self.quota_manager.consume_quota(user_id)
+
+            success, message = await self._send_file_to_email(
+                result,
+                pack_result,
+                recipient_email,
+            )
+            if success:
+                self._cleanup_download_files(result, pack_result)
+                yield event.plain_result(message)
+            else:
+                yield event.plain_result(
+                    MessageFormatter.format_email_error(result, pack_result, message)
+                )
+
+        except Exception as e:
+            logger.error(f"邮件发送本子失败: {e}")
+            if self.debug_mode:
+                import traceback
+
+                logger.error(traceback.format_exc())
+            yield event.plain_result(
+                MessageFormatter.format_error("download_failed", str(e))
+            )
+
+    @filter.command("jmcemail")
+    async def download_photo_email_command(
+        self,
+        event: AstrMessageEvent,
+        album_id: str = None,
+        chapter_index: str = None,
+        recipient_email: str = None,
+    ):
+        """
+        下载指定章节并发送到邮箱
+
+        用法: /jmcemail <本子ID> <章节序号> <邮箱>
+        示例: /jmcemail 123456 3 user@example.com
+        """
+        has_perm, error_msg = self._check_permission(event)
+        if not has_perm:
+            yield event.plain_result(error_msg)
+            return
+
+        if album_id is None or chapter_index is None or recipient_email is None:
+            yield event.plain_result(
+                "❌ 请提供本子ID、章节序号和邮箱\n"
+                "用法: /jmcemail <本子ID> <章节序号> <邮箱>\n"
+                "示例: /jmcemail 123456 3 user@example.com"
+            )
+            return
+
+        album_id = str(album_id).strip()
+        recipient_email = str(recipient_email).strip()
+
+        if not album_id.isdigit():
+            yield event.plain_result(MessageFormatter.format_error("invalid_id"))
+            return
+
+        try:
+            chapter_idx = int(chapter_index)
+            if chapter_idx < 1:
+                yield event.plain_result("❌ 章节序号必须大于0")
+                return
+        except ValueError:
+            yield event.plain_result("❌ 章节序号必须是数字")
+            return
+
+        if not self._is_valid_email(recipient_email):
+            yield event.plain_result("❌ 邮箱格式无效，请输入正确的邮箱地址")
+            return
+
+        user_id = event.get_sender_id()
+        can_download, quota_msg, limit = self._check_download_quota(user_id)
+        if not can_download:
+            yield event.plain_result(quota_msg)
+            return
+
+        try:
+            yield event.plain_result(
+                f"📮 开始下载本子 {album_id} 的第 {chapter_idx} 章节并发送到邮箱 {recipient_email}..."
+            )
+
+            result, pack_result, chapter_meta = await self._prepare_photo_download(
+                album_id,
+                chapter_idx,
+            )
+
+            if result is None:
+                yield event.plain_result(
+                    f"❌ 无法获取章节信息\n可能的原因:\n"
+                    f"• 本子 {album_id} 不存在\n"
+                    f"• 第 {chapter_idx} 章节不存在"
+                )
+                return
+
+            if not result.success:
+                yield event.plain_result(
+                    MessageFormatter.format_error(
+                        "download_failed", result.error_message
+                    )
+                )
+                return
+
+            if limit > 0:
+                self.quota_manager.consume_quota(user_id)
+
+            success, message = await self._send_file_to_email(
+                result,
+                pack_result,
+                recipient_email,
+            )
+            if success:
+                self._cleanup_download_files(result, pack_result)
+                yield event.plain_result(message)
+            else:
+                yield event.plain_result(
+                    MessageFormatter.format_email_error(result, pack_result, message)
+                )
+
+        except Exception as e:
+            logger.error(f"邮件发送章节失败: {e}")
             yield event.plain_result(
                 MessageFormatter.format_error("download_failed", str(e))
             )

--- a/main.py
+++ b/main.py
@@ -147,12 +147,20 @@ class JMCosmosPlugin(Star):
             "recipient": recipient,
         }
 
+    def _validate_email_delivery(self) -> tuple[bool, str]:
+        """检查邮件发送的前置条件"""
+        if self.config_manager.pack_format == "none":
+            return False, "当前打包格式为 none，邮件命令仅支持 zip 或 pdf"
+
+        return self.email_sender.validate_config()
+
     async def _send_file_to_email(
         self, result, pack_result, recipient: str
     ) -> tuple[bool, str]:
         """通过 SMTP 发送文件到邮箱"""
-        if self.config_manager.pack_format == "none":
-            return False, "当前打包格式为 none，邮件命令仅支持 zip 或 pdf"
+        ok, message = self._validate_email_delivery()
+        if not ok:
+            return False, message
 
         if not pack_result.success or not pack_result.output_path:
             return False, pack_result.error_message or "打包失败，无法发送邮件"
@@ -164,6 +172,8 @@ class JMCosmosPlugin(Star):
             body = self.config_manager.email_body_template.format(**context)
         except KeyError as e:
             return False, f"邮件模板变量无效: {e}"
+        except (ValueError, IndexError) as e:
+            return False, f"邮件模板格式无效: {e}"
 
         email_result = await self.email_sender.send_file(
             recipient=recipient,
@@ -524,6 +534,11 @@ class JMCosmosPlugin(Star):
             yield event.plain_result("❌ 邮箱格式无效，请输入正确的邮箱地址")
             return
 
+        ok, message = self._validate_email_delivery()
+        if not ok:
+            yield event.plain_result(f"❌ {message}")
+            return
+
         user_id = event.get_sender_id()
         can_download, quota_msg, limit = self._check_download_quota(user_id)
         if not can_download:
@@ -544,15 +559,14 @@ class JMCosmosPlugin(Star):
                 )
                 return
 
-            if limit > 0:
-                self.quota_manager.consume_quota(user_id)
-
             success, message = await self._send_file_to_email(
                 result,
                 pack_result,
                 recipient_email,
             )
             if success:
+                if limit > 0:
+                    self.quota_manager.consume_quota(user_id)
                 self._cleanup_download_files(result, pack_result)
                 yield event.plain_result(message)
             else:
@@ -617,6 +631,11 @@ class JMCosmosPlugin(Star):
             yield event.plain_result("❌ 邮箱格式无效，请输入正确的邮箱地址")
             return
 
+        ok, message = self._validate_email_delivery()
+        if not ok:
+            yield event.plain_result(f"❌ {message}")
+            return
+
         user_id = event.get_sender_id()
         can_download, quota_msg, limit = self._check_download_quota(user_id)
         if not can_download:
@@ -649,15 +668,14 @@ class JMCosmosPlugin(Star):
                 )
                 return
 
-            if limit > 0:
-                self.quota_manager.consume_quota(user_id)
-
             success, message = await self._send_file_to_email(
                 result,
                 pack_result,
                 recipient_email,
             )
             if success:
+                if limit > 0:
+                    self.quota_manager.consume_quota(user_id)
                 self._cleanup_download_files(result, pack_result)
                 yield event.plain_result(message)
             else:

--- a/main.py
+++ b/main.py
@@ -550,6 +550,10 @@ class JMCosmosPlugin(Star):
                 f"📮 开始下载本子 {album_id} 并发送到邮箱 {recipient_email}，请稍候..."
             )
 
+            preview_result = await self._send_cover_preview_if_needed(event, album_id)
+            if preview_result is not None:
+                yield preview_result
+
             result, pack_result = await self._prepare_album_download(album_id)
             if not result.success:
                 yield event.plain_result(
@@ -644,7 +648,7 @@ class JMCosmosPlugin(Star):
 
         try:
             yield event.plain_result(
-                f"📮 开始下载本子 {album_id} 的第 {chapter_idx} 章节并发送到邮箱 {recipient_email}..."
+                f"⏳ 正在获取本子 {album_id} 的第 {chapter_idx} 章节信息..."
             )
 
             result, pack_result, chapter_meta = await self._prepare_photo_download(
@@ -659,6 +663,14 @@ class JMCosmosPlugin(Star):
                     f"• 第 {chapter_idx} 章节不存在"
                 )
                 return
+
+            photo_title, total_chapters = chapter_meta
+
+            yield event.plain_result(
+                f"📖 找到章节: {photo_title}\n"
+                f"📚 章节: {chapter_idx}/{total_chapters}\n"
+                f"📮 开始下载并发送到邮箱 {recipient_email}..."
+            )
 
             if not result.success:
                 yield event.plain_result(

--- a/main.py
+++ b/main.py
@@ -103,6 +103,32 @@ class JMCosmosPlugin(Star):
         """校验邮箱格式"""
         return bool(re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email))
 
+    def _parse_recipient_emails(self, raw: str) -> tuple[list[str], str]:
+        """解析并校验收件邮箱列表。
+
+        支持英文逗号、中文逗号以及逗号两侧空格；空项会自动忽略，重复邮箱会去重。
+        """
+        normalized = str(raw).replace("，", ",").strip()
+        if not normalized:
+            return [], "❌ 请提供至少一个有效邮箱地址"
+
+        recipients: list[str] = []
+        seen: set[str] = set()
+        for item in normalized.split(","):
+            email = item.strip()
+            if not email:
+                continue
+            if not self._is_valid_email(email):
+                return [], f"❌ 邮箱格式无效: {email}"
+            if email not in seen:
+                seen.add(email)
+                recipients.append(email)
+
+        if not recipients:
+            return [], "❌ 请提供至少一个有效邮箱地址"
+
+        return recipients, ""
+
     def _check_download_quota(self, user_id: str) -> tuple[bool, str, int]:
         """检查下载配额"""
         limit = self.config_manager.daily_download_limit
@@ -155,13 +181,17 @@ class JMCosmosPlugin(Star):
         return self.email_sender.validate_config()
 
     async def _send_file_to_email(
-        self, result, pack_result, recipient: str
+        self, result, pack_result, recipients: list[str]
     ) -> tuple[bool, str]:
         """通过 SMTP 发送文件到邮箱"""
         if not pack_result.success or not pack_result.output_path:
             return False, pack_result.error_message or "打包失败，无法发送邮件"
 
-        context = self._build_email_context(result, pack_result, recipient)
+        if not recipients:
+            return False, "未提供有效的收件邮箱"
+
+        recipient_text = ", ".join(recipients)
+        context = self._build_email_context(result, pack_result, recipient_text)
 
         try:
             subject = self.config_manager.email_subject_template.format(**context)
@@ -172,7 +202,7 @@ class JMCosmosPlugin(Star):
             return False, f"邮件模板格式无效: {e}"
 
         email_result = await self.email_sender.send_file(
-            recipient=recipient,
+            recipients=recipients,
             file_path=pack_result.output_path,
             subject=subject,
             body=body,
@@ -184,7 +214,7 @@ class JMCosmosPlugin(Star):
         return True, MessageFormatter.format_email_send_result(
             result,
             pack_result,
-            recipient,
+            recipient_text,
         )
 
     async def _send_file_to_platform(
@@ -529,8 +559,9 @@ class JMCosmosPlugin(Star):
             yield event.plain_result(MessageFormatter.format_error("invalid_id"))
             return
 
-        if not self._is_valid_email(recipient_email):
-            yield event.plain_result("❌ 邮箱格式无效，请输入正确的邮箱地址")
+        recipients, email_error = self._parse_recipient_emails(recipient_email)
+        if email_error:
+            yield event.plain_result(email_error)
             return
 
         ok, message = self._validate_email_delivery()
@@ -546,7 +577,7 @@ class JMCosmosPlugin(Star):
 
         try:
             yield event.plain_result(
-                f"📮 开始下载本子 {album_id} 并发送到邮箱 {recipient_email}，请稍候..."
+                f"📮 开始下载本子 {album_id} 并发送到邮箱 {', '.join(recipients)}，请稍候..."
             )
 
             preview_result = await self._send_cover_preview_if_needed(event, album_id)
@@ -565,7 +596,7 @@ class JMCosmosPlugin(Star):
             success, message = await self._send_file_to_email(
                 result,
                 pack_result,
-                recipient_email,
+                recipients,
             )
             if success:
                 if limit > 0:
@@ -630,8 +661,9 @@ class JMCosmosPlugin(Star):
             yield event.plain_result("❌ 章节序号必须是数字")
             return
 
-        if not self._is_valid_email(recipient_email):
-            yield event.plain_result("❌ 邮箱格式无效，请输入正确的邮箱地址")
+        recipients, email_error = self._parse_recipient_emails(recipient_email)
+        if email_error:
+            yield event.plain_result(email_error)
             return
 
         ok, message = self._validate_email_delivery()
@@ -668,7 +700,7 @@ class JMCosmosPlugin(Star):
             yield event.plain_result(
                 f"📖 找到章节: {photo_title}\n"
                 f"📚 章节: {chapter_idx}/{total_chapters}\n"
-                f"📮 开始下载并发送到邮箱 {recipient_email}..."
+                f"📮 开始下载并发送到邮箱 {', '.join(recipients)}..."
             )
 
             if not result.success:
@@ -682,7 +714,7 @@ class JMCosmosPlugin(Star):
             success, message = await self._send_file_to_email(
                 result,
                 pack_result,
-                recipient_email,
+                recipients,
             )
             if success:
                 if limit > 0:

--- a/main.py
+++ b/main.py
@@ -158,10 +158,6 @@ class JMCosmosPlugin(Star):
         self, result, pack_result, recipient: str
     ) -> tuple[bool, str]:
         """通过 SMTP 发送文件到邮箱"""
-        ok, message = self._validate_email_delivery()
-        if not ok:
-            return False, message
-
         if not pack_result.success or not pack_result.output_path:
             return False, pack_result.error_message or "打包失败，无法发送邮件"
 
@@ -262,8 +258,11 @@ class JMCosmosPlugin(Star):
 
     async def _send_cover_preview_if_needed(
         self, event: AstrMessageEvent, album_id: str
-    ) -> None:
-        """按配置发送封面预览"""
+    ) -> object | None:
+        """按配置发送封面预览。
+
+        返回非 None 时，调用方应将其 yield 给框架发送。
+        """
         if not self.config_manager.send_cover_preview:
             return
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -101,6 +101,19 @@ def integration_config(temp_download_dir: Path) -> dict[str, Any]:
         "debug_mode": True,
         "jm_username": TEST_USERNAME,
         "jm_password": TEST_PASSWORD,
+        "smtp_enabled": False,
+        "smtp_host": "",
+        "smtp_port": 465,
+        "smtp_use_ssl": True,
+        "smtp_use_tls": False,
+        "smtp_username": "",
+        "smtp_password": "",
+        "smtp_from_email": "",
+        "smtp_from_name": "JM-Cosmos II",
+        "email_subject_template": "[JM-Cosmos II] {title} ({album_id})",
+        "email_body_template": "下载任务已完成。\n\n标题: {title}",
+        "email_max_attachment_mb": 20,
+        "email_send_timeout": 60,
     }
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,6 +40,71 @@ sys.modules["astrbot"] = MagicMock()
 sys.modules["astrbot.api"] = mock_astrbot_api
 sys.modules["astrbot.api.logger"] = mock_logger
 
+# Mock astrbot 子模块，供 main.py 导入
+mock_message_components = types.ModuleType("astrbot.api.message_components")
+mock_message_components.Plain = MagicMock()
+mock_message_components.File = MagicMock()
+mock_message_components.Image = MagicMock()
+sys.modules["astrbot.api.message_components"] = mock_message_components
+
+mock_event_module = types.ModuleType("astrbot.api.event")
+
+
+class _MockFilter:
+    @staticmethod
+    def command(_name):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+class _MockAstrMessageEvent:
+    pass
+
+
+class _MockMessageChain:
+    def __init__(self, chain):
+        self.chain = chain
+
+
+mock_event_module.AstrMessageEvent = _MockAstrMessageEvent
+mock_event_module.MessageChain = _MockMessageChain
+mock_event_module.filter = _MockFilter()
+sys.modules["astrbot.api.event"] = mock_event_module
+
+mock_star_module = types.ModuleType("astrbot.api.star")
+
+
+class _MockContext:
+    pass
+
+
+class _MockStar:
+    def __init__(self, context=None):
+        self.context = context
+
+
+class _MockStarTools:
+    @staticmethod
+    def get_data_dir(_name):
+        return Path(".")
+
+
+def _mock_register(*_args, **_kwargs):
+    def decorator(cls):
+        return cls
+
+    return decorator
+
+
+mock_star_module.Context = _MockContext
+mock_star_module.Star = _MockStar
+mock_star_module.StarTools = _MockStarTools
+mock_star_module.register = _mock_register
+sys.modules["astrbot.api.star"] = mock_star_module
+mock_astrbot_api.AstrBotConfig = dict
+
 # 将插件目录添加到 Python 路径
 PLUGIN_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PLUGIN_ROOT))
@@ -55,21 +120,80 @@ sys.modules["astrbot_plugin_jm_cosmos"] = plugin_pkg
 
 # 预先导入核心模块并注册
 from core import base as core_base  # noqa: E402
+from core import auth as core_auth  # noqa: E402
+from core import browser as core_browser  # noqa: E402
 from core import constants as core_constants  # noqa: E402
+from core import downloader as core_downloader  # noqa: E402
+from core import mailer as core_mailer  # noqa: E402
+from core import packer as core_packer  # noqa: E402
+from core import quota as core_quota  # noqa: E402
 
 # 设置 core 子包
 core_pkg = types.ModuleType("astrbot_plugin_jm_cosmos.core")
 core_pkg.__path__ = [str(PLUGIN_ROOT / "core")]
 core_pkg.__package__ = "astrbot_plugin_jm_cosmos.core"
+core_pkg.JMAuthManager = core_auth.JMAuthManager
+core_pkg.JMBrowser = core_browser.JMBrowser
+core_pkg.JMDownloadManager = core_downloader.JMDownloadManager
+core_pkg.DownloadResult = core_downloader.DownloadResult
+core_pkg.JMEmailSender = core_mailer.JMEmailSender
+core_pkg.EmailSendResult = core_mailer.EmailSendResult
+core_pkg.JMPacker = core_packer.JMPacker
+core_pkg.DownloadQuotaManager = core_quota.DownloadQuotaManager
+core_pkg.JMClientMixin = core_base.JMClientMixin
+core_pkg.JMConfigManager = core_base.JMConfigManager
 core_pkg.constants = core_constants
 core_pkg.base = core_base
 sys.modules["astrbot_plugin_jm_cosmos.core"] = core_pkg
 sys.modules["astrbot_plugin_jm_cosmos.core.constants"] = core_constants
+sys.modules["astrbot_plugin_jm_cosmos.core.base"] = core_base
+sys.modules["astrbot_plugin_jm_cosmos.core.auth"] = core_auth
+sys.modules["astrbot_plugin_jm_cosmos.core.browser"] = core_browser
+sys.modules["astrbot_plugin_jm_cosmos.core.downloader"] = core_downloader
+sys.modules["astrbot_plugin_jm_cosmos.core.mailer"] = core_mailer
+sys.modules["astrbot_plugin_jm_cosmos.core.packer"] = core_packer
+sys.modules["astrbot_plugin_jm_cosmos.core.quota"] = core_quota
+
 
 # 设置 utils 子包
+class _MockMessageFormatter:
+    @staticmethod
+    def format_error(error_type: str, detail: str = "") -> str:
+        msg = f"❌ {error_type}"
+        if detail:
+            msg += f"\n详情: {detail}"
+        return msg
+
+    @staticmethod
+    def format_email_error(_result, _pack_result, detail: str) -> str:
+        return f"⚠️ 邮件发送失败: {detail}"
+
+    @staticmethod
+    def format_email_send_result(_result, _pack_result, recipient: str) -> str:
+        return f"📮 已发送到邮箱: {recipient}"
+
+
+def _mock_generate_album_filename(
+    album_id: str,
+    password: str = "",
+    chapter_idx: int | None = None,
+    show_password: bool = False,
+) -> str:
+    suffix = f"_Ch{chapter_idx}" if chapter_idx is not None else ""
+    pw = f"#PW{password}" if show_password and password else ""
+    return f"{album_id}{suffix}{pw}"
+
+
+async def _mock_send_with_recall(_event, _message_chain, _delay: int = 60) -> None:
+    return None
+
+
 utils_pkg = types.ModuleType("astrbot_plugin_jm_cosmos.utils")
 utils_pkg.__path__ = [str(PLUGIN_ROOT / "utils")]
 utils_pkg.__package__ = "astrbot_plugin_jm_cosmos.utils"
+utils_pkg.MessageFormatter = _MockMessageFormatter
+utils_pkg.generate_album_filename = _mock_generate_album_filename
+utils_pkg.send_with_recall = _mock_send_with_recall
 sys.modules["astrbot_plugin_jm_cosmos.utils"] = utils_pkg
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -101,6 +101,19 @@ def sample_plugin_config() -> dict[str, Any]:
         "debug_mode": False,
         "jm_username": "",
         "jm_password": "",
+        "smtp_enabled": False,
+        "smtp_host": "",
+        "smtp_port": 465,
+        "smtp_use_ssl": True,
+        "smtp_use_tls": False,
+        "smtp_username": "",
+        "smtp_password": "",
+        "smtp_from_email": "",
+        "smtp_from_name": "JM-Cosmos II",
+        "email_subject_template": "[JM-Cosmos II] {title} ({album_id})",
+        "email_body_template": "下载任务已完成。\n\n标题: {title}",
+        "email_max_attachment_mb": 20,
+        "email_send_timeout": 60,
     }
 
 
@@ -126,6 +139,19 @@ def config_with_admin() -> dict[str, Any]:
         "debug_mode": False,
         "jm_username": "testuser",
         "jm_password": "testpass",
+        "smtp_enabled": True,
+        "smtp_host": "smtp.example.com",
+        "smtp_port": 465,
+        "smtp_use_ssl": True,
+        "smtp_use_tls": False,
+        "smtp_username": "sender@example.com",
+        "smtp_password": "secret",
+        "smtp_from_email": "sender@example.com",
+        "smtp_from_name": "JM-Cosmos II",
+        "email_subject_template": "[JM-Cosmos II] {title} ({album_id})",
+        "email_body_template": "下载任务已完成。\n\n标题: {title}",
+        "email_max_attachment_mb": 20,
+        "email_send_timeout": 60,
     }
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -66,6 +66,17 @@ class TestConfigManagerDefaults:
         """测试调试模式默认禁用"""
         assert config_manager.debug_mode is False
 
+    def test_smtp_defaults(self, config_manager):
+        """测试 SMTP 默认配置"""
+        assert config_manager.smtp_enabled is False
+        assert config_manager.smtp_host == ""
+        assert config_manager.smtp_port == 465
+        assert config_manager.smtp_use_ssl is True
+        assert config_manager.smtp_use_tls is False
+        assert config_manager.smtp_from_name == "JM-Cosmos II"
+        assert config_manager.email_max_attachment_mb == 20
+        assert config_manager.email_send_timeout == 60
+
 
 class TestAdminPermissions:
     """管理员权限测试"""
@@ -124,6 +135,14 @@ class TestCredentials:
         assert config_manager_with_admin.has_credentials() is True
         assert config_manager_with_admin.jm_username == "testuser"
         assert config_manager_with_admin.jm_password == "testpass"
+
+    def test_smtp_config_when_enabled(self, config_manager_with_admin):
+        """测试启用 SMTP 后的配置读取"""
+        assert config_manager_with_admin.smtp_enabled is True
+        assert config_manager_with_admin.smtp_host == "smtp.example.com"
+        assert config_manager_with_admin.smtp_username == "sender@example.com"
+        assert config_manager_with_admin.smtp_password == "secret"
+        assert config_manager_with_admin.smtp_from_email == "sender@example.com"
 
     def test_cookies_file_path(self, config_manager, data_dir):
         """测试 cookies 文件路径"""

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -230,16 +230,13 @@ class TestFormatHelp:
 
     def test_format_help_contains_commands(self):
         """测试帮助信息包含所有命令"""
-        # 验证帮助文本的核心内容
-        help_text = """📚 JM-Cosmos II - 漫画下载插件
-【基本命令】
-/jm <ID>     - 下载指定ID的本子
-/jmemail <ID> <邮箱> - 下载本子并发送到邮箱
-/jms <关键词> - 搜索漫画
-/jmi <ID>    - 查看本子详情
-"""
+        help_text = RealMessageFormatter.format_help()
+
         assert "/jm" in help_text
         assert "/jmemail" in help_text
+        assert "/jmcemail" in help_text
+        assert "\n/jmemail" in help_text
+        assert "\n/jmcemail" in help_text
         assert "/jms" in help_text
         assert "/jmi" in help_text
 

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -5,12 +5,32 @@
 注意：由于 formatter.py 使用相对导入，我们直接复制格式化逻辑进行测试。
 """
 
+import importlib.util
+import sys
+from pathlib import Path
+
 
 # 由于 utils/formatter.py 使用相对导入 (from ..core.constants)，
 # 在独立测试环境中难以正确导入。
 # 这里我们创建一个测试用的简化版 MessageFormatter 来验证逻辑。
 
 from core.constants import CATEGORY_NAMES, ORDER_NAMES, TIME_NAMES
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+FORMATTER_PATH = PLUGIN_ROOT / "utils" / "formatter.py"
+FORMATTER_MODULE_NAME = "astrbot_plugin_jm_cosmos.utils.formatter_real"
+
+if FORMATTER_MODULE_NAME in sys.modules:
+    formatter_module = sys.modules[FORMATTER_MODULE_NAME]
+else:
+    spec = importlib.util.spec_from_file_location(FORMATTER_MODULE_NAME, FORMATTER_PATH)
+    formatter_module = importlib.util.module_from_spec(spec)
+    sys.modules[FORMATTER_MODULE_NAME] = formatter_module
+    assert spec.loader is not None
+    spec.loader.exec_module(formatter_module)
+
+RealMessageFormatter = formatter_module.MessageFormatter
 
 
 class TestMessageFormatterLogic:
@@ -168,11 +188,41 @@ class TestFormatDownloadResult:
 
     def test_format_email_result_contains_recipient(self):
         """测试邮件发送结果格式化包含收件人"""
+        from unittest.mock import MagicMock
+
         recipient = "user@example.com"
-        formatted = f"✅ 下载完成！\n📮 已发送到邮箱: {recipient}"
+
+        result = MagicMock()
+        result.success = True
+        result.title = "测试本子"
+        result.author = "测试作者"
+        result.photo_count = 2
+        result.image_count = 10
+
+        pack_result = MagicMock()
+        pack_result.success = True
+        pack_result.output_path = "demo.zip"
+        pack_result.format = "zip"
+        pack_result.encrypted = False
+        pack_result.error_message = None
+
+        formatted = RealMessageFormatter.format_email_send_result(
+            result,
+            pack_result,
+            recipient,
+        )
+
+        error_formatted = RealMessageFormatter.format_email_error(
+            result,
+            pack_result,
+            "SMTP 连接失败",
+        )
 
         assert "已发送到邮箱" in formatted
         assert recipient in formatted
+        assert "邮件发送失败" in error_formatted
+        assert "SMTP 连接失败" in error_formatted
+        assert "测试本子" in error_formatted
 
 
 class TestFormatHelp:

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -166,6 +166,14 @@ class TestFormatDownloadResult:
         assert "下载失败" in formatted
         assert "网络连接超时" in formatted
 
+    def test_format_email_result_contains_recipient(self):
+        """测试邮件发送结果格式化包含收件人"""
+        recipient = "user@example.com"
+        formatted = f"✅ 下载完成！\n📮 已发送到邮箱: {recipient}"
+
+        assert "已发送到邮箱" in formatted
+        assert recipient in formatted
+
 
 class TestFormatHelp:
     """格式化帮助信息测试"""
@@ -176,10 +184,12 @@ class TestFormatHelp:
         help_text = """📚 JM-Cosmos II - 漫画下载插件
 【基本命令】
 /jm <ID>     - 下载指定ID的本子
+/jmemail <ID> <邮箱> - 下载本子并发送到邮箱
 /jms <关键词> - 搜索漫画
 /jmi <ID>    - 查看本子详情
 """
         assert "/jm" in help_text
+        assert "/jmemail" in help_text
         assert "/jms" in help_text
         assert "/jmi" in help_text
 

--- a/tests/unit/test_mailer.py
+++ b/tests/unit/test_mailer.py
@@ -1,0 +1,105 @@
+"""
+邮件发送器测试
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestJMEmailSenderConfig:
+    """SMTP 配置检查测试"""
+
+    def test_validate_config_disabled(self, config_manager):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager)
+        success, message = sender.validate_config()
+
+        assert success is False
+        assert "未启用" in message
+
+    def test_validate_config_success(self, config_manager_with_admin):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        success, message = sender.validate_config()
+
+        assert success is True
+        assert message == ""
+
+
+class TestJMEmailSenderAttachment:
+    """附件检查测试"""
+
+    def test_validate_attachment_missing(self, config_manager_with_admin):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        success, message = sender.validate_attachment(Path("missing.zip"))
+
+        assert success is False
+        assert "不存在" in message
+
+    def test_validate_attachment_too_large(self, config_manager_with_admin, temp_dir):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "large.zip"
+        file_path.write_bytes(b"x" * 16 * 1024 * 1024)
+        sender.config.plugin_config["email_max_attachment_mb"] = 10
+
+        success, message = sender.validate_attachment(file_path)
+
+        assert success is False
+        assert "附件过大" in message
+
+
+class TestJMEmailSenderSend:
+    """邮件发送测试"""
+
+    def test_send_file_sync_success(self, config_manager_with_admin, temp_dir):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+
+        smtp_instance = MagicMock()
+        smtp_context = MagicMock()
+        smtp_context.__enter__.return_value = smtp_instance
+        smtp_context.__exit__.return_value = None
+        smtp_instance.send_message.return_value = {}
+
+        with patch("core.mailer.smtplib.SMTP_SSL", return_value=smtp_context):
+            result = sender._send_file_sync(
+                "user@example.com",
+                file_path,
+                "subject",
+                "body",
+            )
+
+        assert result.success is True
+        assert result.recipient == "user@example.com"
+        smtp_instance.login.assert_called_once()
+        smtp_instance.send_message.assert_called_once()
+
+    def test_send_file_sync_failure(self, config_manager_with_admin, temp_dir):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+
+        with patch(
+            "core.mailer.smtplib.SMTP_SSL",
+            side_effect=RuntimeError("smtp failed"),
+        ):
+            result = sender._send_file_sync(
+                "user@example.com",
+                file_path,
+                "subject",
+                "body",
+            )
+
+        assert result.success is False
+        assert "smtp failed" in result.error_message

--- a/tests/unit/test_mailer.py
+++ b/tests/unit/test_mailer.py
@@ -3,7 +3,9 @@
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 class TestJMEmailSenderConfig:
@@ -26,6 +28,43 @@ class TestJMEmailSenderConfig:
 
         assert success is True
         assert message == ""
+
+    def test_validate_config_invalid_port(self, config_manager_with_admin):
+        from core.mailer import JMEmailSender
+
+        config_manager_with_admin.plugin_config["smtp_port"] = 0
+        sender = JMEmailSender(config_manager_with_admin)
+
+        success, message = sender.validate_config()
+
+        assert success is False
+        assert "SMTP 端口必须大于 0" in message
+
+    def test_validate_config_ssl_tls_conflict(self, config_manager_with_admin):
+        from core.mailer import JMEmailSender
+
+        config_manager_with_admin.plugin_config["smtp_use_ssl"] = True
+        config_manager_with_admin.plugin_config["smtp_use_tls"] = True
+        sender = JMEmailSender(config_manager_with_admin)
+
+        success, message = sender.validate_config()
+
+        assert success is False
+        assert "SSL" in message and "STARTTLS" in message
+
+    def test_validate_config_missing_required_fields(self, config_manager_with_admin):
+        from core.mailer import JMEmailSender
+
+        config_manager_with_admin.plugin_config["smtp_host"] = ""
+        config_manager_with_admin.plugin_config["smtp_password"] = ""
+        sender = JMEmailSender(config_manager_with_admin)
+
+        success, message = sender.validate_config()
+
+        assert success is False
+        assert "缺少" in message
+        assert "smtp_host" in message
+        assert "smtp_password" in message
 
 
 class TestJMEmailSenderAttachment:
@@ -52,6 +91,36 @@ class TestJMEmailSenderAttachment:
 
         assert success is False
         assert "附件过大" in message
+
+    def test_validate_attachment_success_under_limit(
+        self, config_manager_with_admin, temp_dir
+    ):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "small.zip"
+        file_path.write_bytes(b"x" * 1024 * 1024)
+        sender.config.plugin_config["email_max_attachment_mb"] = 10
+
+        success, message = sender.validate_attachment(file_path)
+
+        assert success is True
+        assert message == ""
+
+    def test_validate_attachment_limit_disabled(
+        self, config_manager_with_admin, temp_dir
+    ):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "anysize.zip"
+        file_path.write_bytes(b"x" * 16 * 1024 * 1024)
+        sender.config.plugin_config["email_max_attachment_mb"] = 0
+
+        success, message = sender.validate_attachment(file_path)
+
+        assert success is True
+        assert message == ""
 
 
 class TestJMEmailSenderSend:
@@ -80,6 +149,7 @@ class TestJMEmailSenderSend:
 
         assert result.success is True
         assert result.recipient == "user@example.com"
+        assert result.message_id is not None
         smtp_instance.login.assert_called_once()
         smtp_instance.send_message.assert_called_once()
 
@@ -103,3 +173,144 @@ class TestJMEmailSenderSend:
 
         assert result.success is False
         assert "smtp failed" in result.error_message
+        assert result.message_id is None or result.message_id.startswith("<")
+
+    def test_send_file_sync_starttls_success(self, config_manager_with_admin, temp_dir):
+        from core.mailer import JMEmailSender
+
+        config_manager_with_admin.plugin_config["smtp_use_ssl"] = False
+        config_manager_with_admin.plugin_config["smtp_use_tls"] = True
+        config_manager_with_admin.plugin_config["smtp_port"] = 587
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+
+        smtp_instance = MagicMock()
+        smtp_context = MagicMock()
+        smtp_context.__enter__.return_value = smtp_instance
+        smtp_context.__exit__.return_value = None
+        smtp_instance.send_message.return_value = {}
+
+        with patch("core.mailer.smtplib.SMTP", return_value=smtp_context):
+            result = sender._send_file_sync(
+                "user@example.com",
+                file_path,
+                "subject",
+                "body",
+            )
+
+        assert result.success is True
+        assert result.message_id is not None
+        smtp_instance.starttls.assert_called_once()
+        smtp_instance.login.assert_called_once()
+        smtp_instance.send_message.assert_called_once()
+
+    def test_send_file_sync_partial_recipient_failure(
+        self, config_manager_with_admin, temp_dir
+    ):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+
+        smtp_instance = MagicMock()
+        smtp_context = MagicMock()
+        smtp_context.__enter__.return_value = smtp_instance
+        smtp_context.__exit__.return_value = None
+        smtp_instance.send_message.return_value = {
+            "user@example.com": (550, b"mailbox unavailable")
+        }
+
+        with patch("core.mailer.smtplib.SMTP_SSL", return_value=smtp_context):
+            result = sender._send_file_sync(
+                "user@example.com",
+                file_path,
+                "subject",
+                "body",
+            )
+
+        assert result.success is False
+        assert "部分收件人发送失败" in result.error_message
+        assert result.message_id is not None
+
+    @pytest.mark.asyncio
+    async def test_send_file_config_validation_fails(
+        self, config_manager_with_admin, temp_dir
+    ):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+        sender.validate_config = MagicMock(return_value=(False, "配置错误"))
+        sender.validate_attachment = MagicMock()
+        sender._run_sync = AsyncMock()
+
+        result = await sender.send_file(
+            "user@example.com",
+            file_path,
+            "subject",
+            "body",
+        )
+
+        assert result.success is False
+        assert result.error_message == "配置错误"
+        sender._run_sync.assert_not_awaited()
+        sender.validate_attachment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_file_attachment_validation_fails(
+        self, config_manager_with_admin, temp_dir
+    ):
+        from core.mailer import JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+        sender.validate_config = MagicMock(return_value=(True, ""))
+        sender.validate_attachment = MagicMock(return_value=(False, "附件错误"))
+        sender._run_sync = AsyncMock()
+
+        result = await sender.send_file(
+            "user@example.com",
+            file_path,
+            "subject",
+            "body",
+        )
+
+        assert result.success is False
+        assert result.error_message == "附件错误"
+        sender._run_sync.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_file_success_uses_run_sync(
+        self, config_manager_with_admin, temp_dir
+    ):
+        from core.mailer import EmailSendResult, JMEmailSender
+
+        sender = JMEmailSender(config_manager_with_admin)
+        file_path = temp_dir / "demo.zip"
+        file_path.write_bytes(b"demo")
+        sender.validate_config = MagicMock(return_value=(True, ""))
+        sender.validate_attachment = MagicMock(return_value=(True, ""))
+        expected = EmailSendResult(True, "user@example.com", message_id="<id>")
+
+        async def fake_run_sync(func, *args):
+            assert func == sender._send_file_sync
+            assert args == ("user@example.com", file_path, "subject", "body")
+            return expected
+
+        sender._run_sync = AsyncMock(side_effect=fake_run_sync)
+
+        result = await sender.send_file(
+            "user@example.com",
+            file_path,
+            "subject",
+            "body",
+        )
+
+        assert result is expected
+        sender._run_sync.assert_awaited_once()
+        sender.validate_config.assert_called_once()
+        sender.validate_attachment.assert_called_once_with(file_path)

--- a/tests/unit/test_mailer.py
+++ b/tests/unit/test_mailer.py
@@ -141,17 +141,19 @@ class TestJMEmailSenderSend:
 
         with patch("core.mailer.smtplib.SMTP_SSL", return_value=smtp_context):
             result = sender._send_file_sync(
-                "user@example.com",
+                ["user@example.com", "other@example.com"],
                 file_path,
                 "subject",
                 "body",
             )
 
         assert result.success is True
-        assert result.recipient == "user@example.com"
+        assert result.recipient == "user@example.com, other@example.com"
         assert result.message_id is not None
         smtp_instance.login.assert_called_once()
         smtp_instance.send_message.assert_called_once()
+        sent_message = smtp_instance.send_message.call_args.args[0]
+        assert sent_message["To"] == "user@example.com, other@example.com"
 
     def test_send_file_sync_failure(self, config_manager_with_admin, temp_dir):
         from core.mailer import JMEmailSender
@@ -165,7 +167,7 @@ class TestJMEmailSenderSend:
             side_effect=RuntimeError("smtp failed"),
         ):
             result = sender._send_file_sync(
-                "user@example.com",
+                ["user@example.com", "other@example.com"],
                 file_path,
                 "subject",
                 "body",
@@ -193,7 +195,7 @@ class TestJMEmailSenderSend:
 
         with patch("core.mailer.smtplib.SMTP", return_value=smtp_context):
             result = sender._send_file_sync(
-                "user@example.com",
+                ["user@example.com", "other@example.com"],
                 file_path,
                 "subject",
                 "body",
@@ -224,7 +226,7 @@ class TestJMEmailSenderSend:
 
         with patch("core.mailer.smtplib.SMTP_SSL", return_value=smtp_context):
             result = sender._send_file_sync(
-                "user@example.com",
+                ["user@example.com", "other@example.com"],
                 file_path,
                 "subject",
                 "body",
@@ -248,7 +250,7 @@ class TestJMEmailSenderSend:
         sender._run_sync = AsyncMock()
 
         result = await sender.send_file(
-            "user@example.com",
+            ["user@example.com", "other@example.com"],
             file_path,
             "subject",
             "body",
@@ -256,6 +258,7 @@ class TestJMEmailSenderSend:
 
         assert result.success is False
         assert result.error_message == "配置错误"
+        assert result.recipient == "user@example.com, other@example.com"
         sender._run_sync.assert_not_awaited()
         sender.validate_attachment.assert_not_called()
 
@@ -273,7 +276,7 @@ class TestJMEmailSenderSend:
         sender._run_sync = AsyncMock()
 
         result = await sender.send_file(
-            "user@example.com",
+            ["user@example.com", "other@example.com"],
             file_path,
             "subject",
             "body",
@@ -281,6 +284,7 @@ class TestJMEmailSenderSend:
 
         assert result.success is False
         assert result.error_message == "附件错误"
+        assert result.recipient == "user@example.com, other@example.com"
         sender._run_sync.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -294,17 +298,26 @@ class TestJMEmailSenderSend:
         file_path.write_bytes(b"demo")
         sender.validate_config = MagicMock(return_value=(True, ""))
         sender.validate_attachment = MagicMock(return_value=(True, ""))
-        expected = EmailSendResult(True, "user@example.com", message_id="<id>")
+        expected = EmailSendResult(
+            True,
+            "user@example.com, other@example.com",
+            message_id="<id>",
+        )
 
         async def fake_run_sync(func, *args):
             assert func == sender._send_file_sync
-            assert args == ("user@example.com", file_path, "subject", "body")
+            assert args == (
+                ["user@example.com", "other@example.com"],
+                file_path,
+                "subject",
+                "body",
+            )
             return expected
 
         sender._run_sync = AsyncMock(side_effect=fake_run_sync)
 
         result = await sender.send_file(
-            "user@example.com",
+            ["user@example.com", "other@example.com"],
             file_path,
             "subject",
             "body",

--- a/tests/unit/test_main_email.py
+++ b/tests/unit/test_main_email.py
@@ -108,6 +108,49 @@ async def test_jmemail_checks_delivery_preconditions_before_download():
 
 
 @pytest.mark.asyncio
+async def test_jmemail_rejects_invalid_email_before_download():
+    """邮箱格式无效时不应开始下载"""
+    plugin = build_plugin()
+    plugin._prepare_album_download = AsyncMock(
+        side_effect=AssertionError("should not run")
+    )
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "not-an-email",
+        )
+    ]
+
+    assert results == ["❌ 邮箱格式无效，请输入正确的邮箱地址"]
+    assert plugin._prepare_album_download.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_jmemail_stops_when_quota_check_fails():
+    """配额不足时不应开始下载"""
+    plugin = build_plugin()
+    plugin._check_download_quota = MagicMock(return_value=(False, "额度不足", 3))
+    plugin._prepare_album_download = AsyncMock(
+        side_effect=AssertionError("should not run")
+    )
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "user@example.com",
+        )
+    ]
+
+    assert results == ["额度不足"]
+    assert plugin._prepare_album_download.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_jmemail_does_not_consume_quota_when_send_fails():
     """邮件发送失败时不应消耗配额"""
     plugin = build_plugin()
@@ -205,6 +248,75 @@ async def test_jmemail_consumes_quota_after_send_success():
     plugin.quota_manager.consume_quota.assert_called_once_with("10001")
     plugin._cleanup_download_files.assert_called_once_with(result, pack_result)
     assert results[-1] == "发送成功"
+
+
+@pytest.mark.asyncio
+async def test_jmemail_download_failure_skips_quota_and_cleanup():
+    """下载失败时不应扣配额或清理文件"""
+    plugin = build_plugin()
+    failed_result = SimpleNamespace(
+        success=False,
+        error_message="下载失败",
+    )
+    plugin._prepare_album_download = AsyncMock(return_value=(failed_result, None))
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "user@example.com",
+        )
+    ]
+
+    assert any("下载失败" in item for item in results)
+    assert plugin.quota_manager.consume_quota.call_count == 0
+    assert plugin._cleanup_download_files.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_jmcemail_returns_not_found_message_when_chapter_missing():
+    """章节不存在时应返回与 jmc 一致的错误信息"""
+    plugin = build_plugin()
+    plugin._prepare_photo_download = AsyncMock(return_value=(None, None, None))
+
+    results = [
+        item
+        async for item in plugin.download_photo_email_command(
+            FakeEvent(),
+            "123456",
+            "3",
+            "user@example.com",
+        )
+    ]
+
+    assert results[1] == (
+        "❌ 无法获取章节信息\n可能的原因:\n• 本子 123456 不存在\n• 第 3 章节不存在"
+    )
+
+
+@pytest.mark.asyncio
+async def test_jmcemail_download_failure_skips_quota_and_cleanup():
+    """章节下载失败时不应扣配额或清理文件"""
+    plugin = build_plugin()
+    failed_result = SimpleNamespace(success=False, error_message="章节下载失败")
+    plugin._prepare_photo_download = AsyncMock(
+        return_value=(failed_result, None, ("第3话", 12))
+    )
+
+    results = [
+        item
+        async for item in plugin.download_photo_email_command(
+            FakeEvent(),
+            "123456",
+            "3",
+            "user@example.com",
+        )
+    ]
+
+    assert any("章节下载失败" in item for item in results)
+    assert plugin.quota_manager.consume_quota.call_count == 0
+    assert plugin._cleanup_download_files.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main_email.py
+++ b/tests/unit/test_main_email.py
@@ -62,6 +62,42 @@ def build_plugin(pack_format: str = "zip") -> JMCosmosPlugin:
     return plugin
 
 
+def test_parse_recipient_emails_supports_multiple_delimiters_and_dedup():
+    """应支持中英文逗号、空格并自动去重"""
+    plugin = build_plugin()
+
+    recipients, error = plugin._parse_recipient_emails(
+        "a@example.com， b@example.com, a@example.com ,, c@example.com"
+    )
+
+    assert error == ""
+    assert recipients == [
+        "a@example.com",
+        "b@example.com",
+        "c@example.com",
+    ]
+
+
+def test_parse_recipient_emails_rejects_invalid_email():
+    """存在非法邮箱时应返回具体错误"""
+    plugin = build_plugin()
+
+    recipients, error = plugin._parse_recipient_emails("a@example.com, bad-email")
+
+    assert recipients == []
+    assert error == "❌ 邮箱格式无效: bad-email"
+
+
+def test_parse_recipient_emails_rejects_empty_input():
+    """空邮箱参数应返回明确提示"""
+    plugin = build_plugin()
+
+    recipients, error = plugin._parse_recipient_emails("， ,  ")
+
+    assert recipients == []
+    assert error == "❌ 请提供至少一个有效邮箱地址"
+
+
 def build_download_result():
     """构造下载结果"""
     return SimpleNamespace(
@@ -124,8 +160,57 @@ async def test_jmemail_rejects_invalid_email_before_download():
         )
     ]
 
-    assert results == ["❌ 邮箱格式无效，请输入正确的邮箱地址"]
+    assert results == ["❌ 邮箱格式无效: not-an-email"]
     assert plugin._prepare_album_download.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_jmemail_accepts_multiple_emails_with_cn_comma_and_spaces():
+    """应支持多个邮箱、中文逗号和空格"""
+    plugin = build_plugin()
+    result = build_download_result()
+    pack_result = build_pack_result()
+    plugin._prepare_album_download = AsyncMock(return_value=(result, pack_result))
+    plugin._send_file_to_email = AsyncMock(return_value=(True, "发送成功"))
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "a@example.com， b@example.com",
+        )
+    ]
+
+    plugin._send_file_to_email.assert_awaited_once_with(
+        result,
+        pack_result,
+        ["a@example.com", "b@example.com"],
+    )
+    assert "a@example.com, b@example.com" in results[0]
+
+
+@pytest.mark.asyncio
+async def test_jmemail_ignores_empty_items_and_deduplicates_recipients():
+    """空项应忽略，重复邮箱应去重"""
+    plugin = build_plugin()
+    result = build_download_result()
+    pack_result = build_pack_result()
+    plugin._prepare_album_download = AsyncMock(return_value=(result, pack_result))
+    plugin._send_file_to_email = AsyncMock(return_value=(True, "发送成功"))
+
+    async for _ in plugin.download_album_email_command(
+        FakeEvent(),
+        "123456",
+        "a@example.com,,a@example.com,b@example.com",
+    ):
+        pass
+
+    plugin._send_file_to_email.assert_awaited_once_with(
+        result,
+        pack_result,
+        ["a@example.com", "b@example.com"],
+    )
 
 
 @pytest.mark.asyncio
@@ -225,6 +310,35 @@ async def test_jmcemail_matches_jmc_progress_messages():
         "📖 找到章节: 第3话\n📚 章节: 3/12\n📮 开始下载并发送到邮箱 user@example.com..."
     )
     assert results[-1] == "发送成功"
+
+
+@pytest.mark.asyncio
+async def test_jmcemail_accepts_multiple_emails():
+    """jmcemail 应支持多个收件邮箱"""
+    plugin = build_plugin()
+    result = build_download_result()
+    pack_result = build_pack_result()
+    plugin._prepare_photo_download = AsyncMock(
+        return_value=(result, pack_result, ("第3话", 12))
+    )
+    plugin._send_file_to_email = AsyncMock(return_value=(True, "发送成功"))
+
+    results = [
+        item
+        async for item in plugin.download_photo_email_command(
+            FakeEvent(),
+            "123456",
+            "3",
+            "a@example.com,b@example.com",
+        )
+    ]
+
+    plugin._send_file_to_email.assert_awaited_once_with(
+        result,
+        pack_result,
+        ["a@example.com", "b@example.com"],
+    )
+    assert "a@example.com, b@example.com" in results[1]
 
 
 @pytest.mark.asyncio
@@ -329,9 +443,52 @@ async def test_send_file_to_email_handles_invalid_template_format():
     success, message = await plugin._send_file_to_email(
         build_download_result(),
         build_pack_result(),
-        "user@example.com",
+        ["user@example.com"],
     )
 
     assert success is False
     assert "邮件模板格式无效" in message
     assert plugin.email_sender.send_file.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_file_to_email_sends_to_all_recipients():
+    """应通过一次发送请求处理所有收件邮箱"""
+    plugin = build_plugin()
+    plugin.email_sender.send_file = AsyncMock(
+        return_value=SimpleNamespace(success=True, error_message=None)
+    )
+
+    success, message = await plugin._send_file_to_email(
+        build_download_result(),
+        build_pack_result(),
+        ["a@example.com", "b@example.com"],
+    )
+
+    assert success is True
+    assert "a@example.com, b@example.com" in message
+    plugin.email_sender.send_file.assert_awaited_once_with(
+        recipients=["a@example.com", "b@example.com"],
+        file_path=build_pack_result().output_path,
+        subject="[JM] 测试本子",
+        body="标题: 测试本子",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_file_to_email_reports_failure_from_smtp():
+    """底层发送失败时应返回错误信息"""
+    plugin = build_plugin()
+    plugin.email_sender.send_file = AsyncMock(
+        return_value=SimpleNamespace(success=False, error_message="SMTP 连接失败")
+    )
+
+    success, message = await plugin._send_file_to_email(
+        build_download_result(),
+        build_pack_result(),
+        ["a@example.com", "b@example.com"],
+    )
+
+    assert success is False
+    assert message == "SMTP 连接失败"
+    plugin.email_sender.send_file.assert_awaited_once()

--- a/tests/unit/test_main_email.py
+++ b/tests/unit/test_main_email.py
@@ -58,6 +58,7 @@ def build_plugin(pack_format: str = "zip") -> JMCosmosPlugin:
     plugin._check_permission = MagicMock(return_value=(True, ""))
     plugin._check_download_quota = MagicMock(return_value=(True, "", 3))
     plugin._cleanup_download_files = MagicMock()
+    plugin._send_cover_preview_if_needed = AsyncMock(return_value=None)
     return plugin
 
 
@@ -127,6 +128,60 @@ async def test_jmemail_does_not_consume_quota_when_send_fails():
     assert plugin.quota_manager.consume_quota.call_count == 0
     assert plugin._cleanup_download_files.call_count == 0
     assert any("邮件发送失败" in item for item in results)
+
+
+@pytest.mark.asyncio
+async def test_jmemail_reuses_cover_preview_flow():
+    """jmemail 应与 jm 一样先发送封面/详情预览"""
+    plugin = build_plugin()
+    event = FakeEvent()
+    plugin._prepare_album_download = AsyncMock(
+        return_value=(build_download_result(), build_pack_result())
+    )
+    plugin._send_file_to_email = AsyncMock(return_value=(True, "发送成功"))
+    plugin._send_cover_preview_if_needed = AsyncMock(return_value="预览消息")
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            event,
+            "123456",
+            "user@example.com",
+        )
+    ]
+
+    plugin._send_cover_preview_if_needed.assert_awaited_once_with(event, "123456")
+    assert results[1] == "预览消息"
+
+
+@pytest.mark.asyncio
+async def test_jmcemail_matches_jmc_progress_messages():
+    """jmcemail 应与 jmc 一样先提示章节解析结果"""
+    plugin = build_plugin()
+    plugin._prepare_photo_download = AsyncMock(
+        return_value=(
+            build_download_result(),
+            build_pack_result(),
+            ("第3话", 12),
+        )
+    )
+    plugin._send_file_to_email = AsyncMock(return_value=(True, "发送成功"))
+
+    results = [
+        item
+        async for item in plugin.download_photo_email_command(
+            FakeEvent(),
+            "123456",
+            "3",
+            "user@example.com",
+        )
+    ]
+
+    assert results[0] == "⏳ 正在获取本子 123456 的第 3 章节信息..."
+    assert results[1] == (
+        "📖 找到章节: 第3话\n📚 章节: 3/12\n📮 开始下载并发送到邮箱 user@example.com..."
+    )
+    assert results[-1] == "发送成功"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main_email.py
+++ b/tests/unit/test_main_email.py
@@ -1,0 +1,170 @@
+"""邮件命令流程测试"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+MAIN_PATH = PLUGIN_ROOT / "main.py"
+MAIN_MODULE_NAME = "astrbot_plugin_jm_cosmos.main"
+
+if MAIN_MODULE_NAME in sys.modules:
+    main_module = sys.modules[MAIN_MODULE_NAME]
+else:
+    spec = importlib.util.spec_from_file_location(MAIN_MODULE_NAME, MAIN_PATH)
+    main_module = importlib.util.module_from_spec(spec)
+    sys.modules[MAIN_MODULE_NAME] = main_module
+    assert spec.loader is not None
+    spec.loader.exec_module(main_module)
+
+JMCosmosPlugin = main_module.JMCosmosPlugin
+
+
+class FakeEvent:
+    """简化的事件对象"""
+
+    def __init__(self, user_id: str = "10001", group_id: str | None = None):
+        self.user_id = user_id
+        self.group_id = group_id
+
+    def get_sender_id(self) -> str:
+        return self.user_id
+
+    def get_group_id(self) -> str | None:
+        return self.group_id
+
+    def plain_result(self, message: str) -> str:
+        return message
+
+
+def build_plugin(pack_format: str = "zip") -> JMCosmosPlugin:
+    """构造最小可测试插件实例"""
+    plugin = JMCosmosPlugin.__new__(JMCosmosPlugin)
+    plugin.config_manager = SimpleNamespace(
+        pack_format=pack_format,
+        email_subject_template="[JM] {title}",
+        email_body_template="标题: {title}",
+        auto_delete_after_send=True,
+    )
+    plugin.email_sender = MagicMock()
+    plugin.email_sender.validate_config.return_value = (True, "")
+    plugin.quota_manager = MagicMock()
+    plugin.debug_mode = False
+    plugin._check_permission = MagicMock(return_value=(True, ""))
+    plugin._check_download_quota = MagicMock(return_value=(True, "", 3))
+    plugin._cleanup_download_files = MagicMock()
+    return plugin
+
+
+def build_download_result():
+    """构造下载结果"""
+    return SimpleNamespace(
+        success=True,
+        album_id="123456",
+        title="测试本子",
+        author="测试作者",
+        photo_count=3,
+        image_count=25,
+        save_path=Path("downloads/123456"),
+    )
+
+
+def build_pack_result():
+    """构造打包结果"""
+    return SimpleNamespace(
+        success=True,
+        output_path=Path("downloads/123456.zip"),
+        format="zip",
+        encrypted=False,
+        error_message=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_jmemail_checks_delivery_preconditions_before_download():
+    """邮件命令应在下载前检查前置条件"""
+    plugin = build_plugin(pack_format="none")
+    plugin._prepare_album_download = AsyncMock(
+        side_effect=AssertionError("should not run")
+    )
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "user@example.com",
+        )
+    ]
+
+    assert plugin._prepare_album_download.await_count == 0
+    assert results == ["❌ 当前打包格式为 none，邮件命令仅支持 zip 或 pdf"]
+
+
+@pytest.mark.asyncio
+async def test_jmemail_does_not_consume_quota_when_send_fails():
+    """邮件发送失败时不应消耗配额"""
+    plugin = build_plugin()
+    plugin._prepare_album_download = AsyncMock(
+        return_value=(build_download_result(), build_pack_result())
+    )
+    plugin._send_file_to_email = AsyncMock(return_value=(False, "SMTP 连接失败"))
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "user@example.com",
+        )
+    ]
+
+    assert plugin.quota_manager.consume_quota.call_count == 0
+    assert plugin._cleanup_download_files.call_count == 0
+    assert any("邮件发送失败" in item for item in results)
+
+
+@pytest.mark.asyncio
+async def test_jmemail_consumes_quota_after_send_success():
+    """邮件发送成功后才消耗配额并清理文件"""
+    plugin = build_plugin()
+    result = build_download_result()
+    pack_result = build_pack_result()
+    plugin._prepare_album_download = AsyncMock(return_value=(result, pack_result))
+    plugin._send_file_to_email = AsyncMock(return_value=(True, "发送成功"))
+
+    results = [
+        item
+        async for item in plugin.download_album_email_command(
+            FakeEvent(),
+            "123456",
+            "user@example.com",
+        )
+    ]
+
+    plugin.quota_manager.consume_quota.assert_called_once_with("10001")
+    plugin._cleanup_download_files.assert_called_once_with(result, pack_result)
+    assert results[-1] == "发送成功"
+
+
+@pytest.mark.asyncio
+async def test_send_file_to_email_handles_invalid_template_format():
+    """非法邮件模板应返回明确错误"""
+    plugin = build_plugin()
+    plugin.config_manager.email_subject_template = "[JM] {title"
+    plugin.email_sender.send_file = AsyncMock()
+
+    success, message = await plugin._send_file_to_email(
+        build_download_result(),
+        build_pack_result(),
+        "user@example.com",
+    )
+
+    assert success is False
+    assert "邮件模板格式无效" in message
+    assert plugin.email_sender.send_file.await_count == 0

--- a/utils/formatter.py
+++ b/utils/formatter.py
@@ -328,6 +328,20 @@ day(今日) week(本周) month(本月) all(全部)
         return "\n".join(lines)
 
     @staticmethod
+    def format_email_send_result(result, pack_result, recipient: str) -> str:
+        """格式化邮件发送成功结果"""
+        lines = [MessageFormatter.format_download_result(result, pack_result)]
+        lines.append(f"📮 已发送到邮箱: {recipient}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_email_error(result, pack_result, detail: str) -> str:
+        """格式化邮件发送失败结果"""
+        lines = [MessageFormatter.format_download_result(result, pack_result)]
+        lines.append(f"⚠️ 邮件发送失败: {detail}")
+        return "\n".join(lines)
+
+    @staticmethod
     def format_download_progress(status: str, current: int, total: int) -> str:
         """
         格式化下载进度
@@ -362,6 +376,8 @@ day(今日) week(本周) month(本月) all(全部)
 【基本命令】
 /jm <ID>     - 下载指定ID的本子
 /jmc <ID> <章节> - 下载指定本子的指定章节
+/jmemail <ID> <邮箱> - 下载本子并发送到邮箱
+/jmcemail <ID> <章节> <邮箱> - 下载章节并发送到邮箱
 /jms <关键词> [页码] - 搜索漫画
 /jmi <ID>    - 查看本子详情
 /jmrank      - 查看排行榜
@@ -376,6 +392,7 @@ day(今日) week(本周) month(本月) all(全部)
 
 【使用示例】
 /jm 123456       - 下载ID为123456的本子
+/jmemail 123456 user@example.com - 下载并发送到邮箱
 /jms 标签名 2    - 搜索包含该标签的漫画（第2页）
 /jmrank week     - 查看周排行榜
 /jmrec hanman    - 浏览韩漫热门

--- a/utils/formatter.py
+++ b/utils/formatter.py
@@ -376,8 +376,8 @@ day(今日) week(本周) month(本月) all(全部)
 【基本命令】
 /jm <ID>     - 下载指定ID的本子
 /jmc <ID> <章节> - 下载指定本子的指定章节
-/jmemail <ID> <邮箱> - 下载本子并发送到邮箱
-/jmcemail <ID> <章节> <邮箱> - 下载章节并发送到邮箱
+/jmemail <ID> <邮箱[,邮箱2,...]> - 下载本子并发送到邮箱
+/jmcemail <ID> <章节> <邮箱[,邮箱2,...]> - 下载章节并发送到邮箱
 /jms <关键词> [页码] - 搜索漫画
 /jmi <ID>    - 查看本子详情
 /jmrank      - 查看排行榜
@@ -393,6 +393,7 @@ day(今日) week(本周) month(本月) all(全部)
 【使用示例】
 /jm 123456       - 下载ID为123456的本子
 /jmemail 123456 user@example.com - 下载并发送到邮箱
+/jmemail 123456 a@example.com,b@example.com - 下载并发送到多个邮箱
 /jms 标签名 2    - 搜索包含该标签的漫画（第2页）
 /jmrank week     - 查看周排行榜
 /jmrec hanman    - 浏览韩漫热门

--- a/uv.lock
+++ b/uv.lock
@@ -127,7 +127,7 @@ wheels = [
 
 [[package]]
 name = "jm-cosmos-ii"
-version = "2.6.3"
+version = "2.6.6"
 source = { virtual = "." }
 dependencies = [
     { name = "jmcomic" },


### PR DESCRIPTION
## 变更概述

本次改动为插件新增了基于 SMTP 的邮件投递能力，支持将整本漫画或指定章节打包后发送到指定邮箱，并补齐了该功能所需的配置、文档、错误处理、配额控制与测试覆盖。

## 主要内容

### 1. 新增邮件投递命令

新增两条命令：

- `/jmemail <ID> <邮箱>`：下载整本并发送到邮箱
- `/jmcemail <本子ID> <章节序号> <邮箱>`：下载指定章节并发送到邮箱

邮件命令复用了现有下载与打包逻辑，支持当前插件已有的：

- ZIP / PDF 打包格式
- 打包密码
- 文件命名规则
- 下载后的自动清理

### 2. 新增 SMTP 邮件发送模块

新增独立的邮件发送模块 `core/mailer.py`，用于处理 SMTP 附件发送流程，支持：

- SMTP 配置合法性校验
- SSL / STARTTLS 连接模式
- 附件大小限制校验
- 邮件主题与正文模板渲染
- 打包文件作为邮件附件发送

同时在插件主流程中完成接入，使邮件功能可以直接复用现有下载结果。

### 3. 新增 SMTP 配置项与配置读取能力

在配置层补充了邮件发送所需的完整配置项，包括：

- `smtp_enabled`
- `smtp_host`
- `smtp_port`
- `smtp_use_ssl`
- `smtp_use_tls`
- `smtp_username`
- `smtp_password`
- `smtp_from_email`
- `smtp_from_name`
- `email_subject_template`
- `email_body_template`
- `email_max_attachment_mb`
- `email_send_timeout`

并同步更新：

- `core/base/config.py`
- `_conf_schema.json`
- 测试配置样例

### 4. 完善邮件命令执行流程

围绕邮件命令的实际使用场景，对执行流程做了补全和修正：

- 在下载前先校验邮件发送前置条件，避免 SMTP 未配置或 `pack_format=none` 时仍继续下载
- 只有在邮件实际发送成功后才消耗每日下载配额，避免“没收到邮件却被扣额度”
- 对邮件模板格式错误提供明确报错，避免误报为下载失败
- 失败时保留本地文件，方便排查和二次处理

### 5. 保持邮件命令与原有下载命令的交互一致性

为了让新增命令的使用体验与现有命令一致，本次也对聊天侧交互做了对齐：

- `/jmemail` 的交互流程与 `/jm` 保持一致
  - 开始下载提示
  - 封面 / 漫画详情预览
  - 复用现有的预览撤回逻辑

- `/jmcemail` 的交互流程与 `/jmc` 保持一致
  - 获取章节信息提示
  - 章节标题与章节序号提示
  - 然后继续下载并发送到邮箱

### 6. 更新文档说明

更新 `README.md`，补充：

- 新命令使用方式
- SMTP 配置项说明
- 邮件发送配置示例
- 邮件发送行为说明
- 常见问题说明

使用户可以直接根据文档完成配置和使用。

### 7. 补充测试覆盖

新增和更新了与邮件功能相关的单元测试，覆盖内容包括：

- SMTP 配置读取
- 附件大小限制
- 邮件发送成功 / 失败场景
- 邮件命令前置校验
- 配额扣减时机
- 模板格式错误处理
- `/jmemail` 与 `/jm` 的交互一致性
- `/jmcemail` 与 `/jmc` 的交互一致性

## 测试

执行命令：

```bash
uv run --with pytest --with pytest-asyncio python -m pytest tests/unit -q
```

结果：

- `119 passed`

## 影响范围

本次 PR 主要是新增邮件投递能力，并补齐其完整配套支持，涉及：

- 命令入口
- 核心邮件发送模块
- 配置项与 schema
- 文档
- 单元测试

对原有下载、搜索、浏览等既有功能没有引入破坏性改动。

## Summary by Sourcery

Add SMTP-based email delivery for downloaded comics and refactor common download/pack/send flows for reuse across chat and email commands.

New Features:
- Introduce SMTP mailer module for sending downloaded comic archives as email attachments.
- Add /jmemail and /jmcemail commands to download full albums or specific chapters and send them to a specified email address.

Enhancements:
- Refactor download, packing, quota checking, and cover preview logic into reusable helpers shared by existing and new commands.
- Extend message formatting to report email send success and failure details, including recipient information.
- Ensure quotas are only consumed after successful email delivery and keep local files on send failures for troubleshooting.

Documentation:
- Update README with new email commands, SMTP configuration options, usage examples, and FAQ entries about common mail issues.
- Document the new mailer module in the project structure overview.

Tests:
- Add unit tests for SMTP configuration and attachment validation, synchronous and async email sending flows, and main email command behavior and edge cases.
- Extend existing config and formatter tests to cover new SMTP-related settings and email result formatting.
- Add AstrBot and core module mocks in test conftest to support testing the main plugin entrypoints.