### PR TITLE
fix: postpone jmcomic type annotation evaluation

### DIFF
--- a/core/base/client.py
+++ b/core/base/client.py
@@ -4,6 +4,8 @@ JMComic 客户端管理模块
 提供底层客户端管理的公共逻辑，供 downloader 和 browser 模块使用。
 """
 
+from __future__ import annotations
+
 import asyncio
 import importlib.util
 from collections.abc import Callable

--- a/core/base/config.py
+++ b/core/base/config.py
@@ -2,6 +2,8 @@
 JMComic 配置管理模块
 """
 
+from __future__ import annotations
+
 import importlib.util
 import os
 from pathlib import Path

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -4,6 +4,8 @@ JMComic 下载管理模块
 专注于下载功能：下载本子、下载章节。
 """
 
+from __future__ import annotations
+
 import importlib.util
 from collections.abc import Callable
 from dataclasses import dataclass


### PR DESCRIPTION
Avoid import-time TypeError when jmcomic is absent by postponing evaluation of JmOption | None annotations. This lets the plugin import cleanly and report jmcomic as unavailable at runtime instead of failing during module import.

## Summary by Sourcery

Bug Fixes:
- Prevent import-time TypeError when jmcomic is missing by postponing evaluation of JmOption-related type annotations.