### PR TITLE
fix: 修复 当napcat存在于Windows虚拟机中时无法获取和发送文件的问题

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -5,6 +5,7 @@
     "hint": "下载的漫画将保存到此目录，可使用相对路径或绝对路径",
     "default": "./downloads"
   },
+  
   "image_suffix": {
     "type": "string",
     "description": "图片格式",

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,6 +3,11 @@ JM-Cosmos II 核心模块
 
 提供下载、浏览、认证、配置、打包、配额等核心功能。
 """
+import threading
+from http.server import SimpleHTTPRequestHandler
+from socketserver import TCPServer
+from pathlib import Path
+import time
 
 from .auth import JMAuthManager
 from .base import JMClientMixin, JMConfigManager
@@ -13,9 +18,76 @@ from .jmcomic_loader import is_jmcomic_available
 from .packer import JMPacker
 from .quota import DownloadQuotaManager
 from .subscribe import SubscriptionManager
+from astrbot.api import logger
 
 # 集中管理 jmcomic 库的可用性检查
 JMCOMIC_AVAILABLE = is_jmcomic_available()
+_http_server = None
+_http_thread = None
+
+
+def start_http_server(directory: Path, port: int = 8639, host: str = "0.0.0.0"):
+    global _http_server, _http_thread
+    """
+    启动 HTTP 文件服务，用于给运行在Windows内的napcat提供文件传输
+    Args:
+        directory: 要共享的目录（Path 对象）
+        port: 监听端口
+        host: 监听地址
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    
+    class CORSRequestHandler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(directory), **kwargs)
+    
+    # 如果已有服务在运行，先停止
+    if _http_server is not None:
+        try:
+            logger.warning("检测到已有HTTP服务正在运行，正在尝试关闭旧服务...")
+            _http_server.shutdown()
+            _http_server.server_close()
+            _http_server = None
+            time.sleep(0.5)  # 等待端口释放
+        except Exception as e:
+            logger.error(f"关闭已存在的HTTP服务时异常: {e}")
+    
+    #  自定义 TCPServer 强制设置 SO_REUSEADDR 
+    import socket
+    class ReuseAddrTCPServer(TCPServer):
+        def server_bind(self):
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            super().server_bind() 
+    
+    # 创建新服务
+    server = ReuseAddrTCPServer((host, port), CORSRequestHandler)
+    _http_server = server
+
+    logger.warning(f"JMComic HTTP服务已开放在： {host}:{port}, serving {directory}")
+    
+    def serve_forever():
+        try:
+            server.serve_forever()
+        except Exception as e:
+            logger.error(f"HTTP服务异常: {e}")
+    
+    _http_thread = threading.Thread(target=serve_forever, daemon=False)
+    _http_thread.start()
+    return server
+
+def stop_http_server():
+    """停止 HTTP 服务（用于插件卸载时清理）"""
+    global _http_server
+    if _http_server is not None:
+        try:
+            _http_server.shutdown()
+            _http_server.server_close()
+            _http_server = None
+            logger.warning("JMComic HTTP服务已被关闭")
+        except Exception as e:
+            logger.error(f"关闭HTTP服务时异常: {e}")
+    else:
+        logger.info("HTTP服务早已被关闭或未开启")
 
 __all__ = [
     "JMCOMIC_AVAILABLE",

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import astrbot.api.message_components as Comp
 from astrbot.api import AstrBotConfig, logger
 from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star, StarTools, register
+from .core import start_http_server
 
 from .core import (
     DownloadQuotaManager,
@@ -40,13 +41,16 @@ class JMCosmosPlugin(Star):
 
     def __init__(self, context: Context, config: AstrBotConfig = None):
         super().__init__(context)
-        self.config = config
+        self.config = config or {}
 
         logger.info("正在初始化 JM-Cosmos II 插件...")
 
         # 获取数据目录
         try:
-            self.data_dir = StarTools.get_data_dir(PLUGIN_NAME)
+            if hasattr(StarTools, "get_plugin_data_dir"):
+                self.data_dir = context.get_plugin_data_dir()
+            else:
+                self.data_dir = StarTools.get_data_dir(PLUGIN_NAME)
             self.data_dir.mkdir(parents=True, exist_ok=True)
             logger.info(f"JM-Cosmos II 数据目录: {self.data_dir}")
         except Exception as e:
@@ -68,6 +72,18 @@ class JMCosmosPlugin(Star):
 
         # 初始化下载配额管理器
         self.quota_manager = DownloadQuotaManager(self.data_dir / "quota.db")
+        
+        # 获取http服务主机和端口
+        self.config = config or {}
+        http_config = config.get("http_server", {})
+        port = http_config.get("port", 8639)
+        host = http_config.get("host", "0.0.0.0") #考虑到是Windows虚拟机，所以需要监听所有地址防止遗漏
+
+        # 启动HTTP服务
+        if http_config.get("enabled", True):
+            start_http_server(self.data_dir / "downloads", port=port, host=host)
+            logger.info(f"JM-Cosmos II HTTP服务已启动，监听 {host}:{port}，共享目录: {self.data_dir}")
+
         # 顺手清理过期配额数据，避免 quota.db 随时间无限增长
         try:
             self.quota_manager.cleanup_old_data()
@@ -316,9 +332,19 @@ class JMCosmosPlugin(Star):
                 and pack_result.output_path
                 and pack_result.format != "none"
             ):
-                # 构建文件路径 - 调试输出
+                download_dir = self.data_dir / "downloads"
                 file_path_str = str(pack_result.output_path)
-                logger.info(f"准备发送文件: {file_path_str}")
+                logger.warning(f"准备发送文件: {file_path_str}")
+
+                relative = pack_result.output_path.relative_to(download_dir)
+                url_path = relative.as_posix()  # 转换为 URL 路径
+                # 读取主机和端口
+                config = self.config or {}
+                http_config = config.get("http_server", {})
+                host = http_config.get("host", "10.211.55.2") #默认值为Windows虚拟机里显示的宿主机地址
+                port = http_config.get("port", 8639)
+                file_url = f"http://{host}:{port}/{url_path}"  # 构建 URL
+                logger.warning(f"转换后文件路径: {file_url}")
 
                 # 构建消息链
                 from astrbot.api.event import MessageChain
@@ -328,11 +354,10 @@ class JMCosmosPlugin(Star):
                         Comp.Plain(result_msg),
                         Comp.File(
                             name=pack_result.output_path.name,
-                            file=file_path_str,
+                            url=file_url,
                         ),
                     ]
                 )
-
                 # 根据配置决定是否使用自动撤回
                 if self.config_manager.auto_recall_enabled:
                     await send_with_recall(
@@ -1334,6 +1359,9 @@ class JMCosmosPlugin(Star):
     async def terminate(self) -> None:
         """插件卸载时取消后台任务"""
         task = getattr(self, "_subscription_task", None)
+        """插件卸载时的清理工作"""
+        from .core import stop_http_server
+        stop_http_server()
         if task is not None and not task.done():
             task.cancel()
             try:


### PR DESCRIPTION
这是我第一次使用git功能，如有问题请见谅qwq
本次修复了当napcat处于Windows虚拟机中或者其他容器的时候，无法正常获取和发送文件的问题
解决思路：通过创建一个内网http文件服务器，让Mac上的下载路径能被映射到对应端口上，且可以使napcat正常访问到文件并通过协议将文件发送到群聊/私聊
测试环境：MacBookPro M1 2020 MacOS14+Astrobot v4.26.0-beta.4 | Windows 11 Arm 虚拟机+napcat 4.18.6
测试过程：输入/jm 350234
测试结果：发送已下载并打包好的zip 成功

那个...第一次参与合作开发，加上对规则不熟悉，此次提交的源代码中破坏了原有的下载路径拼接功能，可能导致在非特殊环境下文件发送异常的问题出现，还请大大重新实现相关逻辑，并能提供一个开关供用户启用和关闭这个功能以切换正常/虚拟机穿透模式
<img width="683" height="716" alt="Screenshot 2026-06-20 at 01 58 30" src="https://github.com/user-attachments/assets/055e217b-7930-4f1b-ade9-5046948281e6" />
<img width="1680" height="1050" alt="Screenshot 2026-06-20 at 02 08 19" src="https://github.com/user-attachments/assets/9eb88c33-5b6f-4e47-8df7-e55b0b141dab" />
<img width="821" height="707" alt="Screenshot 2026-06-20 at 02 08 37" src="https://github.com/user-attachments/assets/bbba3830-67fc-4997-bd6c-d784e72c622e" />

## Summary by Sourcery

Introduce an internal HTTP file server and related configuration to allow JM-Cosmos II to serve downloaded files to napcat instances running inside Windows VMs or similar containerized environments.

New Features:
- Add an embedded HTTP file server that exposes the plugin downloads directory for external access by napcat.
- Allow configuration of HTTP server host, port, and enable flag via plugin config, with a default port of 8639.

Bug Fixes:
- Fix failures to obtain and send files when napcat runs inside a Windows virtual machine or other isolated container by routing file access through the internal HTTP server.

Enhancements:
- Update plugin initialization to use the context-specific plugin data directory when available for better compatibility with newer Astrbot APIs.
- Adjust file sending to reference files via HTTP URLs instead of direct filesystem paths for improved cross-environment accessibility.
- Ensure the HTTP server is cleanly shut down when the plugin is terminated to avoid lingering processes and port conflicts.