### PR TITLE
Fix/pack split采用文件分片发送解决qq官方bot无法发送大文件本子的问题，同时改了一下下载完成文本发送逻辑（单独发送）

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -80,6 +80,12 @@
     "hint": "为ZIP或PDF设置密码，留空则不加密",
     "default": ""
   },
+  "pack_split_threshold": {
+    "type": "int",
+    "description": "拆包体积阈值(字节)",
+    "hint": "打包产物超过此大小时自动拆分为多个分片逐个发送，主要规避QQ官方机器人API的413限制。0=关闭拆包。默认8388608(8MB)。NapCat平台可填0关闭",
+    "default": 8388608
+  },
   "filename_show_password": {
     "type": "bool",
     "description": "文件名显示密码",

--- a/core/base/config.py
+++ b/core/base/config.py
@@ -94,6 +94,14 @@ class JMConfigManager:
         return self.plugin_config.get("pack_password", "")
 
     @property
+    def pack_split_threshold(self) -> int:
+        """拆包体积阈值(字节)，0 表示不拆包"""
+        try:
+            return max(0, int(self.plugin_config.get("pack_split_threshold", 8388608)))
+        except (TypeError, ValueError):
+            return 8388608
+
+    @property
     def filename_show_password(self) -> bool:
         """是否在文件名中显示密码提示"""
         return self.plugin_config.get("filename_show_password", False)

--- a/core/packer.py
+++ b/core/packer.py
@@ -71,6 +71,8 @@ class PackResult:
     format: str
     encrypted: bool
     error_message: str | None = None
+    # 拆包时的全部分片路径；非空时 output_path 指向第一个分片
+    parts: list[Path] | None = None
 
 
 class JMPacker:
@@ -88,7 +90,11 @@ class JMPacker:
         self.password = password
 
     def pack(
-        self, source_dir: Path, output_name: str, output_dir: Path | None = None
+        self,
+        source_dir: Path,
+        output_name: str,
+        output_dir: Path | None = None,
+        max_part_size: int = 0,
     ) -> PackResult:
         """
         打包目录
@@ -97,6 +103,8 @@ class JMPacker:
             source_dir: 源目录
             output_name: 输出文件名（不含扩展名）
             output_dir: 输出目录，默认为源目录的父目录
+            max_part_size: 单个分片最大字节数，>0 时产物超限自动拆包
+                （对 zip/pdf/long_img 生效）
 
         Returns:
             PackResult 打包结果
@@ -116,11 +124,17 @@ class JMPacker:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if self.pack_format == "zip":
-            return self._pack_zip(source_dir, output_name, output_dir)
+            return self._pack_or_split(
+                self._pack_zip, source_dir, output_name, output_dir, max_part_size
+            )
         elif self.pack_format == "pdf":
-            return self._pack_pdf(source_dir, output_name, output_dir)
+            return self._pack_or_split(
+                self._pack_pdf, source_dir, output_name, output_dir, max_part_size
+            )
         elif self.pack_format == "long_img":
-            return self._pack_long_img(source_dir, output_name, output_dir)
+            return self._pack_or_split(
+                self._pack_long_img, source_dir, output_name, output_dir, max_part_size
+            )
         elif self.pack_format == "none":
             return PackResult(
                 success=True, output_path=source_dir, format="none", encrypted=False
@@ -133,6 +147,109 @@ class JMPacker:
                 encrypted=False,
                 error_message=f"不支持的打包格式: {self.pack_format}",
             )
+
+    def _pack_or_split(
+        self,
+        pack_one,
+        source_dir: Path,
+        output_name: str,
+        output_dir: Path,
+        max_part_size: int,
+    ) -> PackResult:
+        """先尝试整体打包；若产物超阈值则按图片分组拆成多个分片。
+
+        Args:
+            pack_one: 形如 (source_dir, output_name, output_dir) -> PackResult 的
+                单包打包方法（_pack_zip / _pack_pdf / _pack_long_img）。
+        """
+        result = pack_one(source_dir, output_name, output_dir)
+        # 不拆包 / 拆包关闭 / 打包失败 / 产物未超限：原样返回
+        if (
+            max_part_size <= 0
+            or not result.success
+            or not result.output_path
+            or result.output_path.stat().st_size <= max_part_size
+        ):
+            return result
+
+        # 整体产物超限：清理后改为分组打包
+        self.cleanup(result.output_path)
+        return self._pack_split(pack_one, source_dir, output_name, output_dir, max_part_size)
+
+    def _pack_split(
+        self,
+        pack_one,
+        source_dir: Path,
+        output_name: str,
+        output_dir: Path,
+        max_part_size: int,
+    ) -> PackResult:
+        
+        import tempfile
+
+        image_files = _collect_images_sorted(source_dir)
+        if not image_files:
+            return PackResult(
+                success=False,
+                output_path=None,
+                format=self.pack_format,
+                encrypted=bool(self.password),
+                error_message="未找到图片文件，无法拆包",
+            )
+
+        groups = self._partition_by_size(image_files, max_part_size)
+        parts: list[Path] = []
+        total = len(groups)
+        for idx, group in enumerate(groups, 1):
+            chunk_dir = Path(tempfile.mkdtemp(prefix="jm_split_"))
+            try:
+                for src in group:
+                    # 保持原相对路径结构（章节/页码），避免重名覆盖
+                    rel = src.relative_to(source_dir)
+                    dst = chunk_dir / rel
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, dst)
+
+                suffix = "" if total == 1 else f"_part{idx}"
+                r = pack_one(chunk_dir, f"{output_name}{suffix}", output_dir)
+                if not r.success or not r.output_path:
+                    # 任一分片失败则整体失败，清理已产出
+                    for p in parts:
+                        self.cleanup(p)
+                    return r
+                parts.append(r.output_path)
+            finally:
+                self.cleanup(chunk_dir)
+
+        return PackResult(
+            success=True,
+            output_path=parts[0],
+            format=self.pack_format,
+            encrypted=bool(self.password),
+            parts=parts,
+        )
+
+    @staticmethod
+    def _partition_by_size(
+        files: list[Path], max_size: int
+    ) -> list[list[Path]]:
+        """按未压缩体积累加分组，每组 ≤ max_size。单文件超限时单独成组。"""
+        groups: list[list[Path]] = []
+        cur: list[Path] = []
+        cur_size = 0
+        for f in files:
+            try:
+                size = f.stat().st_size
+            except OSError:
+                size = 0
+            if cur and cur_size + size > max_size:
+                groups.append(cur)
+                cur, cur_size = [], 0
+            cur.append(f)
+            cur_size += size
+        if cur:
+            groups.append(cur)
+        return groups
 
     def _pack_zip(
         self, source_dir: Path, output_name: str, output_dir: Path

--- a/main.py
+++ b/main.py
@@ -1199,31 +1199,39 @@ class JMCosmosPlugin(Star):
         ):
             from astrbot.api.event import MessageChain
 
+            
+            yield event.plain_result(result_msg)
+
             # 拆包时取全部分片，否则单文件
             parts = pack_result.parts or [pack_result.output_path]
             total = len(parts)
             for idx, part_path in enumerate(parts, 1):
-                # 第一片附带结果说明文字，后续片只带分片序号提示
-                if total > 1:
-                    part_text = (
-                        f"{result_msg}\n📦 分片 {idx}/{total}"
-                        if idx == 1
-                        else f"📦 分片 {idx}/{total}"
-                    )
-                else:
-                    part_text = result_msg
+                # 多分片时每个文件带分片序号提示；单文件时不再附带文字
+                part_text = (
+                    f"📦 分片 {idx}/{total}" if total > 1 else None
+                )
 
                 logger.info(f"准备发送{label}: {part_path}")
 
-                file_chain = MessageChain(
-                    [
-                        Comp.Plain(part_text),
-                        Comp.File(
-                            name=part_path.name,
-                            file=str(part_path),
-                        ),
-                    ]
-                )
+                if part_text:
+                    file_chain = MessageChain(
+                        [
+                            Comp.Plain(part_text),
+                            Comp.File(
+                                name=part_path.name,
+                                file=str(part_path),
+                            ),
+                        ]
+                    )
+                else:
+                    file_chain = MessageChain(
+                        [
+                            Comp.File(
+                                name=part_path.name,
+                                file=str(part_path),
+                            ),
+                        ]
+                    )
 
                 if self.config_manager.auto_recall_enabled:
                     await send_with_recall(

--- a/main.py
+++ b/main.py
@@ -307,6 +307,7 @@ class JMCosmosPlugin(Star):
             pack_result = packer.pack(
                 source_dir=result.save_path,
                 output_name=output_name,
+                max_part_size=self.config_manager.pack_split_threshold,
             )
 
             result_msg = MessageFormatter.format_download_result(result, pack_result)
@@ -316,37 +317,10 @@ class JMCosmosPlugin(Star):
                 and pack_result.output_path
                 and pack_result.format != "none"
             ):
-                # 构建文件路径 - 调试输出
-                file_path_str = str(pack_result.output_path)
-                logger.info(f"准备发送文件: {file_path_str}")
-
-                # 构建消息链
-                from astrbot.api.event import MessageChain
-
-                file_chain = MessageChain(
-                    [
-                        Comp.Plain(result_msg),
-                        Comp.File(
-                            name=pack_result.output_path.name,
-                            file=file_path_str,
-                        ),
-                    ]
-                )
-
-                # 根据配置决定是否使用自动撤回
-                if self.config_manager.auto_recall_enabled:
-                    await send_with_recall(
-                        event,
-                        file_chain,
-                        self.config_manager.auto_recall_delay,
-                    )
-                else:
-                    yield event.chain_result(file_chain.chain)
-
-                # 自动清理
-                if self.config_manager.auto_delete_after_send:
-                    JMPacker.cleanup(result.save_path)
-                    JMPacker.cleanup(pack_result.output_path)
+                async for msg in self._emit_packed_file(
+                    event, result, pack_result, label="文件"
+                ):
+                    yield msg
             else:
                 yield event.plain_result(result_msg)
 
@@ -464,6 +438,7 @@ class JMCosmosPlugin(Star):
             pack_result = packer.pack(
                 source_dir=result.save_path,
                 output_name=output_name,
+                max_part_size=self.config_manager.pack_split_threshold,
             )
 
             result_msg = MessageFormatter.format_download_result(result, pack_result)
@@ -473,35 +448,10 @@ class JMCosmosPlugin(Star):
                 and pack_result.output_path
                 and pack_result.format != "none"
             ):
-                file_path_str = str(pack_result.output_path)
-                logger.info(f"准备发送章节文件: {file_path_str}")
-
-                # 构建消息链
-                from astrbot.api.event import MessageChain
-
-                file_chain = MessageChain(
-                    [
-                        Comp.Plain(result_msg),
-                        Comp.File(
-                            name=pack_result.output_path.name,
-                            file=file_path_str,
-                        ),
-                    ]
-                )
-
-                # 根据配置决定是否使用自动撤回
-                if self.config_manager.auto_recall_enabled:
-                    await send_with_recall(
-                        event,
-                        file_chain,
-                        self.config_manager.auto_recall_delay,
-                    )
-                else:
-                    yield event.chain_result(file_chain.chain)
-
-                if self.config_manager.auto_delete_after_send:
-                    JMPacker.cleanup(result.save_path)
-                    JMPacker.cleanup(pack_result.output_path)
+                async for msg in self._emit_packed_file(
+                    event, result, pack_result, label="章节文件"
+                ):
+                    yield msg
             else:
                 yield event.plain_result(result_msg)
 
@@ -1216,7 +1166,9 @@ class JMCosmosPlugin(Star):
                 password=self.config_manager.pack_password,
             )
             pack_result = packer.pack(
-                source_dir=result.save_path, output_name=output_name
+                source_dir=result.save_path,
+                output_name=output_name,
+                max_part_size=self.config_manager.pack_split_threshold,
             )
 
             # 同步更新订阅记录的已知章节数
@@ -1234,8 +1186,10 @@ class JMCosmosPlugin(Star):
             if not download_succeeded:
                 self._refund_quota(event, quota_reserved)
 
-    async def _emit_packed_file(self, event: AstrMessageEvent, result, pack_result):
-        """统一处理打包文件的发送（含自动撤回与清理），供下载类命令复用"""
+    async def _emit_packed_file(
+        self, event: AstrMessageEvent, result, pack_result, label: str = "文件"
+    ):
+        """统一处理打包文件的发送（含自动撤回与清理），供下载类命令复用。"""
         result_msg = MessageFormatter.format_download_result(result, pack_result)
 
         if (
@@ -1245,26 +1199,43 @@ class JMCosmosPlugin(Star):
         ):
             from astrbot.api.event import MessageChain
 
-            file_chain = MessageChain(
-                [
-                    Comp.Plain(result_msg),
-                    Comp.File(
-                        name=pack_result.output_path.name,
-                        file=str(pack_result.output_path),
-                    ),
-                ]
-            )
+            # 拆包时取全部分片，否则单文件
+            parts = pack_result.parts or [pack_result.output_path]
+            total = len(parts)
+            for idx, part_path in enumerate(parts, 1):
+                # 第一片附带结果说明文字，后续片只带分片序号提示
+                if total > 1:
+                    part_text = (
+                        f"{result_msg}\n📦 分片 {idx}/{total}"
+                        if idx == 1
+                        else f"📦 分片 {idx}/{total}"
+                    )
+                else:
+                    part_text = result_msg
 
-            if self.config_manager.auto_recall_enabled:
-                await send_with_recall(
-                    event, file_chain, self.config_manager.auto_recall_delay
+                logger.info(f"准备发送{label}: {part_path}")
+
+                file_chain = MessageChain(
+                    [
+                        Comp.Plain(part_text),
+                        Comp.File(
+                            name=part_path.name,
+                            file=str(part_path),
+                        ),
+                    ]
                 )
-            else:
-                yield event.chain_result(file_chain.chain)
+
+                if self.config_manager.auto_recall_enabled:
+                    await send_with_recall(
+                        event, file_chain, self.config_manager.auto_recall_delay
+                    )
+                else:
+                    yield event.chain_result(file_chain.chain)
 
             if self.config_manager.auto_delete_after_send:
                 JMPacker.cleanup(result.save_path)
-                JMPacker.cleanup(pack_result.output_path)
+                for part_path in parts:
+                    JMPacker.cleanup(part_path)
         else:
             yield event.plain_result(result_msg)
 


### PR DESCRIPTION
之前在使用qq官方bot时发现能发送小文件，但是对于一些大文件表现是会输出下载完成，但是不会发送。
<img width="1367" height="2017" alt="修改前" src="https://github.com/user-attachments/assets/d80d56de-9b0d-49c0-bd40-7ad9bcba4f02" />

查看astrbot日志显示
<head><title>413 Request Entity Too Large</title></head>
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>stgw</center>
stgw 是腾讯的 STGW 前端网关（Secure Tencent Gateway），即腾讯服务器侧的网关报的错，可以断定问题出在腾讯 QQofficial API 单次媒体上传的体积限制。
与之相关的issue：
https://github.com/GEMILUXVII/astrbot_plugin_jm_cosmos/issues/64
https://github.com/GEMILUXVII/astrbot_plugin_jm_cosmos/issues/69
其中napcat没有复现我认为是napcat 走的是 QQ 客户端协议，文件上传走的是另一套通道，体积上限宽松得多，不会撞腾讯官方 API 的 413
解决方案是把文件分片切割，设计一个拆分大小的阈值，超过就拆分，同时这个阈值用户可以自行设置，不需要可以关闭， 不影响其他适配平台。
我看_emit_packed_file这个方法应该是要进行复用的，实际上没有复用，为了方便统一我进行了复用。
后面发现分片后"下载完成！xxx"没有发出，只是发出了分片文件，查看日志，Prepare to send`明确带有这段文字，我推测是 把文本和文件塞在同一条 msg_type 消息里,但QQ 官方 bot 的群富媒体消息的展示很不稳定，修改之前也遇到过几次直接发出文件但是没有输出"下载完成xxx"文字的情况。我的解决措施是任何情况下都先单独 `yield event.plain_result(result_msg)` 发一条纯文本,把结果说明文字作为独立的 msg_type 文本消息发出去,保证可见;文件消息只承载文件本身.
最终效果
![Uploading 修改后.jpg…]()

## Summary by Sourcery

Introduce configurable file packaging split to enable sending large packed files reliably, and unify packed file sending behavior across download commands.

New Features:
- Add support for splitting packed outputs into multiple parts when exceeding a configurable size threshold, with per-part messaging when sending.
- Expose a pack_split_threshold configuration option to control the maximum part size and allow disabling splitting.

Bug Fixes:
- Ensure QQ official bot reliably sends large packed files by avoiding single oversized uploads and separating status text from file messages to prevent it from being dropped.

Enhancements:
- Refactor packed file sending into a reusable _emit_packed_file helper used by album, photo, and update commands, sending result text as a separate message before file parts.
- Extend packer logic to support conditional splitting for zip, pdf, and long image outputs while preserving directory structure in each part and cleaning up temporary artifacts after sending.